### PR TITLE
fix configuration prefix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { installGoTool, goToolBin, runGoTool } from './utils/tools'
 
 export async function activate(context: ExtensionContext): Promise<void> {
   let { subscriptions } = context
-  const config = workspace.getConfiguration().get('gopls', {}) as any
+  const config = workspace.getConfiguration().get('go', {}) as any
   const enable = config.enable
   if (enable === false) return
 


### PR DESCRIPTION
Hello, 

While using your extension, I noticed a mismatch between the `go` prefix described in the `package.json` and the readme with the prefix defined in the extension code. 