### PR TITLE
Use env to set GOPATH for shells like Fish.

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -42,7 +42,7 @@ async function goBinExists(source: string): Promise<boolean> {
 async function goRun(args: string): Promise<boolean> {
   const gopath = await configDir('tools')
 
-  const cmd = `GOPATH=${gopath} go ${args}`
+  const cmd = `env GOPATH=${gopath} go ${args}`
   const res = await workspace.runTerminalCommand(cmd)
 
   return res.success


### PR DESCRIPTION
In a shell such as fish, trying to install gopls and gomodifytags produces the following errors:

~~~
fish: Unsupported use of '='. To run 'go' with a modified environment, please use 'env GOPATH=/Users/xxx/.config/coc/extensions/coc-go-data/tools go…'
GOPATH=/Users/xxx/.config/coc/extensions/coc-go-data/tools go get -d -u golang.org/x/tools/cmd/gopls
~~~

~~~
fish: Unsupported use of '='. To run 'go' with a modified environment, please use 'env GOPATH=/Users/xxx/.config/coc/extensions/coc-go-data/tools go…'
GOPATH=/Users/xxx/.config/coc/extensions/coc-go-data/tools go get -d -u github.com/fatih/gomodifytags
~~~

The error explains the fix, which sets `$GOPATH` using `env` instead of using the shell to do so.