### PR TITLE
Update binary path

### DIFF
--- a/src/binaries.ts
+++ b/src/binaries.ts
@@ -1,4 +1,4 @@
-export const GOPLS = 'golang.org/x/tools/cmd/gopls'
+export const GOPLS = 'golang.org/x/tools/gopls'
 export const GOMODIFYTAGS = 'github.com/fatih/gomodifytags'
 export const GOTESTS = "github.com/cweill/gotests/..."
 export const GOPLAY = "github.com/haya14busa/goplay/cmd/goplay"


### PR DESCRIPTION
This plugin is currently broken for new installs because it would seem that the tools repository has been restructured. This PR updates it to the new path.