### PR TITLE
Add windows support for goRun

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -4,6 +4,7 @@ import { spawn } from 'child_process'
 import { workspace } from 'coc.nvim'
 import which from 'which'
 import { configDir } from './config'
+import os from 'os'
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -62,7 +63,12 @@ async function goBinExists(source: string): Promise<boolean> {
 async function goRun(args: string): Promise<boolean> {
   const gopath = await configDir('tools')
   const gobin = await configDir('bin')
-  const cmd = `env GOBIN=${gobin} GOPATH=${gopath} GO111MODULE=on go ${args}`
+  const platform = os.platform()
+  let cmd = `env GOBIN=${gobin} GOPATH=${gopath} GO111MODULE=on go ${args}`
+
+  if (platform === 'win32') {
+     cmd = `set GOBIN=${gobin}&set GOPATH=${gopath}&set GO111MODULE=on& go ${args}`;
+  }
 
   try {
     await workspace.runCommand(cmd, gopath)


### PR DESCRIPTION
This pull request contains the solution for issue #73 

- `env` command equivalent implementation on windows.
