### PR TITLE
fix undefined `config.disable`

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,9 +52,9 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
   const clientOptions: LanguageClientOptions = {
     documentSelector: ['go'],
     initializationOptions: () => getConfig().goplsOptions,
-    disableWorkspaceFolders: config.disable.workspaceFolders,
-    disableDiagnostics: config.disable.diagnostics,
-    disableCompletion: config.disable.completion,
+    disableWorkspaceFolders: config.disableWorkspaceFolders,
+    disableDiagnostics: config.disableDiagnostics,
+    disableCompletion: config.disableCompletion,
     // TODO disableSnippetCompletion: config.disable.snippetCompletion,
   }
 


### PR DESCRIPTION
coc-go stopped working for me and I started getting
```
unhandledRejection  Promise {
  <rejected> TypeError: Cannot read property 'workspaceFolders' of undefined
      at registerGopls .config/coc/extensions/node_modules/coc-go/lib/extension.js:53:45
} TypeError: Cannot read property 'workspaceFolders' of undefined
    at registerGopls .config/coc/extensions/node_modules/coc-go/lib/extension.js:53:45
```

I think this is the fix