### PR TITLE
 Use env to set GOPATH for shells like Fish The 2nd.

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -84,7 +84,7 @@ async function goRun(args: string): Promise<boolean> {
   }
   const cmd = isWin
     ? `go ${args}`
-    : `GOBIN=${gobin} go ${args}`
+    : `env GOBIN=${gobin} go ${args}`
   const opts: ExecOptions = {
     env: Object.assign({}, process.env, env),
     cwd: gopath,


### PR DESCRIPTION
This PR is basically the same change as josa42/coc-go/pull/33 and seems to fix josa42/coc-go/issues/111 at least in my environment i have tested with both bash and fish and have not had any issues so far.