### PR TITLE
- is valid package name

### DIFF
--- a/src/utils/impl.ts
+++ b/src/utils/impl.ts
@@ -1,9 +1,9 @@
 import { workspace } from 'coc.nvim'
 import { TextDocument, TextEdit } from 'vscode-languageserver-protocol'
 import { IMPL } from '../binaries'
-import {execTool } from './tools'
+import { execTool } from './tools'
 
-const interfaceRegex = /^(\w+ \*?\w+ )?([\w./]+)$/
+const interfaceRegex = /^(\w+ \*?\w+ )?([\w./-]+)$/
 
 export async function generateImplStubs(document: TextDocument): Promise<void> {
   try {


### PR DESCRIPTION
`svc *Service my-service/router.Server` is a valid impl input, but fails at regex