### PR TITLE
feat: debug nearest test function using vimspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,13 @@
     "update:readme": "./scripts/update-tables.sh",
     "lint": "eslint . --ext .ts,.js",
     "link": "coc-dev link",
-    "unlink": "coc-dev unlink"
+    "unlink": "coc-dev unlink",
+    "format": "prettier --parser typescript --write \"src/**/*.ts\""
+  },
+  "prettier": {
+    "singleQuote": true,
+    "printWidth": 80,
+    "semi": true
   },
   "activationEvents": [
     "onLanguage:go",
@@ -511,6 +517,11 @@
             }
           }
         },
+        "go.debug.vimspector.configuration.name": {
+            "type": "string",
+            "default": "launch",
+            "description": "Specify the name of the vimspector configuration name. The following args will be passed to the configuration: `TestIdentifier`"
+        },
         "go.checkForUpdates": {
           "description": "[EXPERIMENTAL] Check for gopls updates on start.",
           "type": "string",
@@ -626,6 +637,11 @@
         "command": "go.test.toggle"
       },
       {
+        "title": "Debug nearest test function using vimspector",
+        "category": "Go",
+        "command": "go.debug.test.nearest"
+      },
+      {
         "title": "Print extension version",
         "category": "Go",
         "command": "go.version"
@@ -653,6 +669,7 @@
     "coc-dev-tools": "^0.1.0",
     "coc.nvim": "0.0.79",
     "eslint": "^7.9.0",
+    "prettier": "^2.2.0",
     "eslint-config-josa-typescript": "^0.1.2",
     "mocha": "^8.1.3",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "prettier": {
     "singleQuote": true,
     "printWidth": 80,
-    "semi": true
+    "semi": false
   },
   "activationEvents": [
     "onLanguage:go",

--- a/src/binaries.ts
+++ b/src/binaries.ts
@@ -1,7 +1,7 @@
-export const GOPLS = 'golang.org/x/tools/gopls';
-export const GOMODIFYTAGS = 'github.com/fatih/gomodifytags';
-export const GOTESTS = 'github.com/cweill/gotests/...';
-export const GOPLAY = 'github.com/haya14busa/goplay/cmd/goplay';
-export const IMPL = 'github.com/josharian/impl';
+export const GOPLS = 'golang.org/x/tools/gopls'
+export const GOMODIFYTAGS = 'github.com/fatih/gomodifytags'
+export const GOTESTS = 'github.com/cweill/gotests/...'
+export const GOPLAY = 'github.com/haya14busa/goplay/cmd/goplay'
+export const IMPL = 'github.com/josharian/impl'
 
-export const TOOLS = [GOPLS, GOMODIFYTAGS, GOTESTS, GOPLAY, IMPL];
+export const TOOLS = [GOPLS, GOMODIFYTAGS, GOTESTS, GOPLAY, IMPL]

--- a/src/binaries.ts
+++ b/src/binaries.ts
@@ -1,13 +1,7 @@
-export const GOPLS = 'golang.org/x/tools/gopls'
-export const GOMODIFYTAGS = 'github.com/fatih/gomodifytags'
-export const GOTESTS = "github.com/cweill/gotests/..."
-export const GOPLAY = "github.com/haya14busa/goplay/cmd/goplay"
-export const IMPL = "github.com/josharian/impl"
+export const GOPLS = 'golang.org/x/tools/gopls';
+export const GOMODIFYTAGS = 'github.com/fatih/gomodifytags';
+export const GOTESTS = 'github.com/cweill/gotests/...';
+export const GOPLAY = 'github.com/haya14busa/goplay/cmd/goplay';
+export const IMPL = 'github.com/josharian/impl';
 
-export const TOOLS = [
-  GOPLS,
-  GOMODIFYTAGS,
-  GOTESTS,
-  GOPLAY,
-  IMPL,
-]
+export const TOOLS = [GOPLS, GOMODIFYTAGS, GOTESTS, GOPLAY, IMPL];

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,111 +1,120 @@
-import path from 'path'
-import fs from 'fs'
-import { LanguageClient, workspace } from 'coc.nvim'
-import { installGoBin, runGoTool } from './utils/tools'
-import checkLatestTag from './utils/checktag'
+import path from 'path';
+import fs from 'fs';
+import { LanguageClient, workspace } from 'coc.nvim';
+import { installGoBin, runGoTool } from './utils/tools';
+import checkLatestTag from './utils/checktag';
 
-import { GOMODIFYTAGS, GOPLAY, GOPLS, GOTESTS, IMPL, TOOLS } from './binaries'
-import { compareVersions, isValidVersion } from './utils/versions'
+import { GOMODIFYTAGS, GOPLAY, GOPLS, GOTESTS, IMPL, TOOLS } from './binaries';
+import { compareVersions, isValidVersion } from './utils/versions';
 
 export async function version(): Promise<void> {
-  const v1 = await pkgVersion()
-  const v2 = await goplsVersion() || 'unknown'
+  const v1 = await pkgVersion();
+  const v2 = (await goplsVersion()) || 'unknown';
 
-  workspace.showMessage(`Version: coc-go ${v1}; gopls ${v2}`, 'more')
+  workspace.showMessage(`Version: coc-go ${v1}; gopls ${v2}`, 'more');
 }
 
 export async function installGopls(client: LanguageClient): Promise<void> {
-  await installGoBin(GOPLS, true)
+  await installGoBin(GOPLS, true);
 
   if (client.needsStop()) {
-    await client.stop()
-    client.restart()
+    await client.stop();
+    client.restart();
   }
 }
 
-export async function checkGopls(client: LanguageClient, mode: 'ask' | 'inform' | 'install'): Promise<void> {
-
+export async function checkGopls(
+  client: LanguageClient,
+  mode: 'ask' | 'inform' | 'install'
+): Promise<void> {
   const [current, latest] = await Promise.all([
     goplsVersion(),
-    checkLatestTag("golang/tools", /^gopls\//),
-  ])
+    checkLatestTag('golang/tools', /^gopls\//),
+  ]);
 
   try {
-    let install = false
+    let install = false;
     switch (compareVersions(latest, current)) {
       case 0:
-        workspace.showMessage(`[gopls] up-to-date: ${current}`, 'more')
-        break
+        workspace.showMessage(`[gopls] up-to-date: ${current}`, 'more');
+        break;
       case 1:
         switch (mode) {
           case 'install':
-            install = true
-            break
+            install = true;
+            break;
           case 'ask':
-            install = await workspace.showPrompt(`[gopls] Install update? ${current} => ${latest}`)
-            break
+            install = await workspace.showPrompt(
+              `[gopls] Install update? ${current} => ${latest}`
+            );
+            break;
           case 'inform':
-            workspace.showMessage(`[gopls] update available: ${current} => ${latest}`)
-            break
+            workspace.showMessage(
+              `[gopls] update available: ${current} => ${latest}`
+            );
+            break;
         }
 
-        break
+        break;
       case -1:
-        workspace.showMessage(`[gopls] current: ${current} | latest: ${latest}`, 'more')
-        break
+        workspace.showMessage(
+          `[gopls] current: ${current} | latest: ${latest}`,
+          'more'
+        );
+        break;
     }
 
     if (install) {
-      await installGopls(client)
+      await installGopls(client);
     }
   } catch (e) {
-    workspace.showMessage(e.toString(), 'error')
+    workspace.showMessage(e.toString(), 'error');
   }
 }
 
 async function pkgVersion(): Promise<string> {
   try {
-    const pkgPath = path.resolve(__dirname, '..', 'package.json')
-    const pkgContent = await fs.promises.readFile(pkgPath, 'utf8')
-    return JSON.parse(pkgContent).version
+    const pkgPath = path.resolve(__dirname, '..', 'package.json');
+    const pkgContent = await fs.promises.readFile(pkgPath, 'utf8');
+    return JSON.parse(pkgContent).version;
   } catch (err) {
-    console.error(err)
+    console.error(err);
   }
 
-  return ''
+  return '';
 }
 
-
 async function goplsVersion(): Promise<string> {
-  const [, versionOut] = await runGoTool("gopls", ["version"])
+  const [, versionOut] = await runGoTool('gopls', ['version']);
 
-  const m = versionOut.trim().match(/^golang\.org\/x\/tools\/gopls (v?\d+\.\d+\.\d+)/)
+  const m = versionOut
+    .trim()
+    .match(/^golang\.org\/x\/tools\/gopls (v?\d+\.\d+\.\d+)/);
   if (m && isValidVersion(m[1])) {
-    return m[1].replace(/^v/, '')
+    return m[1].replace(/^v/, '');
   }
 
-  return ''
-
+  return '';
 }
 
 export async function installGomodifytags(): Promise<void> {
-  await installGoBin(GOMODIFYTAGS, true)
+  await installGoBin(GOMODIFYTAGS, true);
 }
 
 export async function installGotests(): Promise<void> {
-  await installGoBin(GOTESTS, true)
+  await installGoBin(GOTESTS, true);
 }
 
 export async function installGoplay(): Promise<void> {
-  await installGoBin(GOPLAY, true)
+  await installGoBin(GOPLAY, true);
 }
 
 export async function installImpl(): Promise<void> {
-  await installGoBin(IMPL, true)
+  await installGoBin(IMPL, true);
 }
 
 export async function installTools(): Promise<void> {
   for (const tool of TOOLS) {
-    await installGoBin(tool, true)
+    await installGoBin(tool, true);
   }
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,25 +1,25 @@
-import path from 'path';
-import fs from 'fs';
-import { LanguageClient, workspace } from 'coc.nvim';
-import { installGoBin, runGoTool } from './utils/tools';
-import checkLatestTag from './utils/checktag';
+import path from 'path'
+import fs from 'fs'
+import { LanguageClient, workspace } from 'coc.nvim'
+import { installGoBin, runGoTool } from './utils/tools'
+import checkLatestTag from './utils/checktag'
 
-import { GOMODIFYTAGS, GOPLAY, GOPLS, GOTESTS, IMPL, TOOLS } from './binaries';
-import { compareVersions, isValidVersion } from './utils/versions';
+import { GOMODIFYTAGS, GOPLAY, GOPLS, GOTESTS, IMPL, TOOLS } from './binaries'
+import { compareVersions, isValidVersion } from './utils/versions'
 
 export async function version(): Promise<void> {
-  const v1 = await pkgVersion();
-  const v2 = (await goplsVersion()) || 'unknown';
+  const v1 = await pkgVersion()
+  const v2 = (await goplsVersion()) || 'unknown'
 
-  workspace.showMessage(`Version: coc-go ${v1}; gopls ${v2}`, 'more');
+  workspace.showMessage(`Version: coc-go ${v1}; gopls ${v2}`, 'more')
 }
 
 export async function installGopls(client: LanguageClient): Promise<void> {
-  await installGoBin(GOPLS, true);
+  await installGoBin(GOPLS, true)
 
   if (client.needsStop()) {
-    await client.stop();
-    client.restart();
+    await client.stop()
+    client.restart()
   }
 }
 
@@ -30,91 +30,91 @@ export async function checkGopls(
   const [current, latest] = await Promise.all([
     goplsVersion(),
     checkLatestTag('golang/tools', /^gopls\//),
-  ]);
+  ])
 
   try {
-    let install = false;
+    let install = false
     switch (compareVersions(latest, current)) {
       case 0:
-        workspace.showMessage(`[gopls] up-to-date: ${current}`, 'more');
-        break;
+        workspace.showMessage(`[gopls] up-to-date: ${current}`, 'more')
+        break
       case 1:
         switch (mode) {
           case 'install':
-            install = true;
-            break;
+            install = true
+            break
           case 'ask':
             install = await workspace.showPrompt(
               `[gopls] Install update? ${current} => ${latest}`
-            );
-            break;
+            )
+            break
           case 'inform':
             workspace.showMessage(
               `[gopls] update available: ${current} => ${latest}`
-            );
-            break;
+            )
+            break
         }
 
-        break;
+        break
       case -1:
         workspace.showMessage(
           `[gopls] current: ${current} | latest: ${latest}`,
           'more'
-        );
-        break;
+        )
+        break
     }
 
     if (install) {
-      await installGopls(client);
+      await installGopls(client)
     }
   } catch (e) {
-    workspace.showMessage(e.toString(), 'error');
+    workspace.showMessage(e.toString(), 'error')
   }
 }
 
 async function pkgVersion(): Promise<string> {
   try {
-    const pkgPath = path.resolve(__dirname, '..', 'package.json');
-    const pkgContent = await fs.promises.readFile(pkgPath, 'utf8');
-    return JSON.parse(pkgContent).version;
+    const pkgPath = path.resolve(__dirname, '..', 'package.json')
+    const pkgContent = await fs.promises.readFile(pkgPath, 'utf8')
+    return JSON.parse(pkgContent).version
   } catch (err) {
-    console.error(err);
+    console.error(err)
   }
 
-  return '';
+  return ''
 }
 
 async function goplsVersion(): Promise<string> {
-  const [, versionOut] = await runGoTool('gopls', ['version']);
+  const [, versionOut] = await runGoTool('gopls', ['version'])
 
   const m = versionOut
     .trim()
-    .match(/^golang\.org\/x\/tools\/gopls (v?\d+\.\d+\.\d+)/);
+    .match(/^golang\.org\/x\/tools\/gopls (v?\d+\.\d+\.\d+)/)
   if (m && isValidVersion(m[1])) {
-    return m[1].replace(/^v/, '');
+    return m[1].replace(/^v/, '')
   }
 
-  return '';
+  return ''
 }
 
 export async function installGomodifytags(): Promise<void> {
-  await installGoBin(GOMODIFYTAGS, true);
+  await installGoBin(GOMODIFYTAGS, true)
 }
 
 export async function installGotests(): Promise<void> {
-  await installGoBin(GOTESTS, true);
+  await installGoBin(GOTESTS, true)
 }
 
 export async function installGoplay(): Promise<void> {
-  await installGoBin(GOPLAY, true);
+  await installGoBin(GOPLAY, true)
 }
 
 export async function installImpl(): Promise<void> {
-  await installGoBin(IMPL, true);
+  await installGoBin(IMPL, true)
 }
 
 export async function installTools(): Promise<void> {
   for (const tool of TOOLS) {
-    await installGoBin(tool, true);
+    await installGoBin(tool, true)
   }
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,11 +1,11 @@
-import { workspace } from 'coc.nvim';
-import { TextDocument } from 'vscode-languageserver-protocol';
+import { workspace } from 'coc.nvim'
+import { TextDocument } from 'vscode-languageserver-protocol'
 
 export async function activeTextDocument(): Promise<TextDocument> {
-  const doc = await workspace.document;
+  const doc = await workspace.document
   if (doc.filetype != 'go') {
-    throw 'Not a go document';
+    throw 'Not a go document'
   }
 
-  return doc.textDocument;
+  return doc.textDocument
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,12 +1,11 @@
-import { workspace } from 'coc.nvim'
-import { TextDocument } from 'vscode-languageserver-protocol'
+import { workspace } from 'coc.nvim';
+import { TextDocument } from 'vscode-languageserver-protocol';
 
 export async function activeTextDocument(): Promise<TextDocument> {
-  const doc = await workspace.document
+  const doc = await workspace.document;
   if (doc.filetype != 'go') {
-    throw "Not a go document"
+    throw 'Not a go document';
   }
 
-  return doc.textDocument
+  return doc.textDocument;
 }
-

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,77 +1,101 @@
-import { ExtensionContext, LanguageClient, LanguageClientOptions, commands, services, workspace } from 'coc.nvim'
-import { ChildProcess, spawn } from 'child_process'
-import { commandExists, goBinPath, installGoBin } from './utils/tools'
-import { checkGopls, installGomodifytags, installGoplay, installGopls, installGotests, installImpl, installTools, version } from './commands'
-import { addTags, clearTags, removeTags } from './utils/modify-tags'
-import { getConfig, setStoragePath } from './utils/config'
-import { activeTextDocument } from './editor'
-import { GOPLS } from './binaries'
-import { generateTestsAll, generateTestsExported, generateTestsFunction, toogleTests } from './utils/tests'
-import { openPlayground } from './utils/playground'
-import { generateImplStubs } from './utils/impl'
+import {
+  ExtensionContext,
+  LanguageClient,
+  LanguageClientOptions,
+  commands,
+  services,
+  workspace,
+} from 'coc.nvim';
+import { ChildProcess, spawn } from 'child_process';
+import { commandExists, goBinPath, installGoBin } from './utils/tools';
+import {
+  checkGopls,
+  installGomodifytags,
+  installGoplay,
+  installGopls,
+  installGotests,
+  installImpl,
+  installTools,
+  version,
+} from './commands';
+import { addTags, clearTags, removeTags } from './utils/modify-tags';
+import { getConfig, setStoragePath } from './utils/config';
+import { activeTextDocument } from './editor';
+import { GOPLS } from './binaries';
+import {
+  generateTestsAll,
+  generateTestsExported,
+  generateTestsFunction,
+  toogleTests,
+} from './utils/tests';
+import { openPlayground } from './utils/playground';
+import { generateImplStubs } from './utils/impl';
+import { debugNearestTest } from './utils/debug';
 
 const restartConfigs = [
   'go.goplsArgs',
   'go.goplsOptions',
   'go.goplsPath',
   'go.goplsUseDaemon',
-]
+];
 
 export async function activate(context: ExtensionContext): Promise<void> {
-
-  setStoragePath(context.storagePath)
+  setStoragePath(context.storagePath);
 
   if (getConfig().enable === false) {
-    return
+    return;
   }
 
-  registerGeneral(context)
+  registerGeneral(context);
 
-  registerGopls(context)
-  registerTest(context)
-  registerTags(context)
-  registerPlaygroud(context)
-  registerGoImpl(context)
-  registerTools(context)
+  registerGopls(context);
+  registerTest(context);
+  registerTags(context);
+  registerPlaygroud(context);
+  registerGoImpl(context);
+  registerTools(context);
+  registerDebug(context);
 }
 
 async function registerGeneral(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    commands.registerCommand(
-      "go.version",
-      () => version()
-    ),
-  )
+    commands.registerCommand('go.version', () => version())
+  );
 }
 
 async function registerGopls(context: ExtensionContext): Promise<void> {
-  const config = getConfig()
+  const config = getConfig();
 
-  const command = await goplsPath(config.goplsPath)
+  const command = await goplsPath(config.goplsPath);
   if (!command) {
-    return
+    return;
   }
 
-  const args = config.goplsArgs ? [...config.goplsArgs] : []
+  const args = config.goplsArgs ? [...config.goplsArgs] : [];
 
-  if (config.goplsUseDaemon !== false && !args.find(arg => arg.startsWith('-remote'))) {
+  if (
+    config.goplsUseDaemon !== false &&
+    !args.find((arg) => arg.startsWith('-remote'))
+  ) {
     // Use daemon by default
-    args.push('-remote=auto')
+    args.push('-remote=auto');
   }
 
   // TMPDIR needs to be resetted, because its altered by coc.nvim, which breaks
   // the automatic deamon launching of gopls.
   // See: https://github.com/neoclide/coc.nvim/commit/bdd9a9e1401fe6fdd57a9bd078e3651ecf1e0202
-  const tmpdir = await workspace.nvim.eval('$TMPDIR') as string
+  const tmpdir = (await workspace.nvim.eval('$TMPDIR')) as string;
 
   const server = (): Promise<ChildProcess> => {
-    return new Promise(resolve => {
-      resolve(spawn(command, args, {
-        cwd: workspace.cwd,
-        env: { ...process.env, TMPDIR: tmpdir, ...config.goplsEnv },
-      }))
-    })
-  }
+    return new Promise((resolve) => {
+      resolve(
+        spawn(command, args, {
+          cwd: workspace.cwd,
+          env: { ...process.env, TMPDIR: tmpdir, ...config.goplsEnv },
+        })
+      );
+    });
+  };
 
   // https://github.com/neoclide/coc.nvim/blob/master/src/language-client/client.ts#L684
   const clientOptions: LanguageClientOptions = {
@@ -81,12 +105,12 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
     disableDiagnostics: config.disable.diagnostics,
     disableCompletion: config.disable.completion,
     // TODO disableSnippetCompletion: config.disable.snippetCompletion,
-  }
+  };
 
-  const client = new LanguageClient('go', 'gopls', server, clientOptions)
+  const client = new LanguageClient('go', 'gopls', server, clientOptions);
 
   if (config.checkForUpdates !== 'disabled' && !config.goplsPath) {
-    await checkGopls(client, config.checkForUpdates)
+    await checkGopls(client, config.checkForUpdates);
   }
 
   context.subscriptions.push(
@@ -94,134 +118,114 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
 
     // restart gopls if options changed
     workspace.onDidChangeConfiguration(async (e) => {
-      if (restartConfigs.find(k => e.affectsConfiguration(k))) {
-        await client.stop()
-        client.restart()
+      if (restartConfigs.find((k) => e.affectsConfiguration(k))) {
+        await client.stop();
+        client.restart();
       }
     }),
 
-    commands.registerCommand(
-      "go.install.gopls",
-      () => installGopls(client)
-    )
-  )
+    commands.registerCommand('go.install.gopls', () => installGopls(client))
+  );
 }
 
 async function goplsPath(goplsPath: string): Promise<string | null> {
   if (goplsPath) {
-    if (!await commandExists(goplsPath)) {
-      workspace.showMessage(`goplsPath is configured ("${goplsPath}"), but does not exist!`, 'error')
-      return null
+    if (!(await commandExists(goplsPath))) {
+      workspace.showMessage(
+        `goplsPath is configured ("${goplsPath}"), but does not exist!`,
+        'error'
+      );
+      return null;
     }
 
-    return goplsPath
+    return goplsPath;
   }
 
-  if (!await installGoBin(GOPLS)) {
-    return
+  if (!(await installGoBin(GOPLS))) {
+    return;
   }
 
-  return goBinPath(GOPLS)
+  return goBinPath(GOPLS);
 }
 
 async function registerGoImpl(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    commands.registerCommand(
-      "go.install.impl",
-      () => installImpl()
-    ),
-    commands.registerCommand(
-      "go.impl.cursor",
-      async () => generateImplStubs(await activeTextDocument())
+    commands.registerCommand('go.install.impl', () => installImpl()),
+    commands.registerCommand('go.impl.cursor', async () =>
+      generateImplStubs(await activeTextDocument())
     )
-  )
-
+  );
 }
 
 async function registerTest(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    commands.registerCommand(
-      "go.install.gotests",
-      () => installGotests()
+    commands.registerCommand('go.install.gotests', () => installGotests()),
+    commands.registerCommand('go.test.generate.file', async () =>
+      generateTestsAll(await activeTextDocument())
     ),
-    commands.registerCommand(
-      "go.test.generate.file",
-      async () => generateTestsAll(await activeTextDocument())
+    commands.registerCommand('go.test.generate.exported', async () =>
+      generateTestsExported(await activeTextDocument())
     ),
-    commands.registerCommand(
-      "go.test.generate.exported",
-      async () => generateTestsExported(await activeTextDocument())
+    commands.registerCommand('go.test.generate.function', async () =>
+      generateTestsFunction(await activeTextDocument())
     ),
-    commands.registerCommand(
-      "go.test.generate.function",
-      async () => generateTestsFunction(await activeTextDocument())
-    ),
-    commands.registerCommand(
-      "go.test.toggle",
-      async () => toogleTests(await activeTextDocument())
-    ),
-  )
+    commands.registerCommand('go.test.toggle', async () =>
+      toogleTests(await activeTextDocument())
+    )
+  );
+}
+
+async function registerDebug(context: ExtensionContext): Promise<void> {
+  context.subscriptions.push(
+    commands.registerCommand('go.debug.test.nearest', async () =>
+      debugNearestTest(await activeTextDocument())
+    )
+  );
 }
 
 async function registerTags(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    commands.registerCommand(
-      "go.install.gomodifytags",
-      () => installGomodifytags()
+    commands.registerCommand('go.install.gomodifytags', () =>
+      installGomodifytags()
     ),
-    commands.registerCommand(
-      "go.tags.add",
-      async (...tags) => addTags(await activeTextDocument(), { tags })
+    commands.registerCommand('go.tags.add', async (...tags) =>
+      addTags(await activeTextDocument(), { tags })
     ),
-    commands.registerCommand(
-      "go.tags.add.line",
-      async (...tags) => addTags(await activeTextDocument(), { tags, selection: "line" })
+    commands.registerCommand('go.tags.add.line', async (...tags) =>
+      addTags(await activeTextDocument(), { tags, selection: 'line' })
     ),
-    commands.registerCommand(
-      "go.tags.add.prompt",
-      async () => addTags(await activeTextDocument(), { prompt: true })
+    commands.registerCommand('go.tags.add.prompt', async () =>
+      addTags(await activeTextDocument(), { prompt: true })
     ),
-    commands.registerCommand(
-      "go.tags.remove",
-      async (...tags) => removeTags(await activeTextDocument(), { tags })
+    commands.registerCommand('go.tags.remove', async (...tags) =>
+      removeTags(await activeTextDocument(), { tags })
     ),
-    commands.registerCommand(
-      "go.tags.remove.line",
-      async (...tags) => removeTags(await activeTextDocument(), { tags, selection: "line" })
+    commands.registerCommand('go.tags.remove.line', async (...tags) =>
+      removeTags(await activeTextDocument(), { tags, selection: 'line' })
     ),
-    commands.registerCommand(
-      "go.tags.remove.prompt",
-      async () => removeTags(await activeTextDocument(), { prompt: true })
+    commands.registerCommand('go.tags.remove.prompt', async () =>
+      removeTags(await activeTextDocument(), { prompt: true })
     ),
-    commands.registerCommand(
-      "go.tags.clear",
-      async () => clearTags(await activeTextDocument())
+    commands.registerCommand('go.tags.clear', async () =>
+      clearTags(await activeTextDocument())
     ),
-    commands.registerCommand(
-      "go.tags.clear.line",
-      async () => clearTags(await activeTextDocument(), { selection: "line" })
-    ),
-  )
+    commands.registerCommand('go.tags.clear.line', async () =>
+      clearTags(await activeTextDocument(), { selection: 'line' })
+    )
+  );
 }
 
 async function registerPlaygroud(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    commands.registerCommand(
-      "go.install.goplay",
-      () => installGoplay()
-    ),
-    commands.registerCommand(
-      "go.playground",
-      async () => openPlayground(await activeTextDocument())
+    commands.registerCommand('go.install.goplay', () => installGoplay()),
+    commands.registerCommand('go.playground', async () =>
+      openPlayground(await activeTextDocument())
     )
-  )
+  );
 }
 
 async function registerTools(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
-    commands.registerCommand(
-      "go.install.tools",
-      () => installTools()
-    )
-  )
+    commands.registerCommand('go.install.tools', () => installTools())
+  );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,9 +5,9 @@ import {
   commands,
   services,
   workspace,
-} from 'coc.nvim';
-import { ChildProcess, spawn } from 'child_process';
-import { commandExists, goBinPath, installGoBin } from './utils/tools';
+} from 'coc.nvim'
+import { ChildProcess, spawn } from 'child_process'
+import { commandExists, goBinPath, installGoBin } from './utils/tools'
 import {
   checkGopls,
   installGomodifytags,
@@ -17,74 +17,74 @@ import {
   installImpl,
   installTools,
   version,
-} from './commands';
-import { addTags, clearTags, removeTags } from './utils/modify-tags';
-import { getConfig, setStoragePath } from './utils/config';
-import { activeTextDocument } from './editor';
-import { GOPLS } from './binaries';
+} from './commands'
+import { addTags, clearTags, removeTags } from './utils/modify-tags'
+import { getConfig, setStoragePath } from './utils/config'
+import { activeTextDocument } from './editor'
+import { GOPLS } from './binaries'
 import {
   generateTestsAll,
   generateTestsExported,
   generateTestsFunction,
   toogleTests,
-} from './utils/tests';
-import { openPlayground } from './utils/playground';
-import { generateImplStubs } from './utils/impl';
-import { debugNearestTest } from './utils/debug';
+} from './utils/tests'
+import { openPlayground } from './utils/playground'
+import { generateImplStubs } from './utils/impl'
+import { debugNearestTest } from './utils/debug'
 
 const restartConfigs = [
   'go.goplsArgs',
   'go.goplsOptions',
   'go.goplsPath',
   'go.goplsUseDaemon',
-];
+]
 
 export async function activate(context: ExtensionContext): Promise<void> {
-  setStoragePath(context.storagePath);
+  setStoragePath(context.storagePath)
 
   if (getConfig().enable === false) {
-    return;
+    return
   }
 
-  registerGeneral(context);
+  registerGeneral(context)
 
-  registerGopls(context);
-  registerTest(context);
-  registerTags(context);
-  registerPlaygroud(context);
-  registerGoImpl(context);
-  registerTools(context);
-  registerDebug(context);
+  registerGopls(context)
+  registerTest(context)
+  registerTags(context)
+  registerPlaygroud(context)
+  registerGoImpl(context)
+  registerTools(context)
+  registerDebug(context)
 }
 
 async function registerGeneral(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     commands.registerCommand('go.version', () => version())
-  );
+  )
 }
 
 async function registerGopls(context: ExtensionContext): Promise<void> {
-  const config = getConfig();
+  const config = getConfig()
 
-  const command = await goplsPath(config.goplsPath);
+  const command = await goplsPath(config.goplsPath)
   if (!command) {
-    return;
+    return
   }
 
-  const args = config.goplsArgs ? [...config.goplsArgs] : [];
+  const args = config.goplsArgs ? [...config.goplsArgs] : []
 
   if (
     config.goplsUseDaemon !== false &&
     !args.find((arg) => arg.startsWith('-remote'))
   ) {
     // Use daemon by default
-    args.push('-remote=auto');
+    args.push('-remote=auto')
   }
 
   // TMPDIR needs to be resetted, because its altered by coc.nvim, which breaks
   // the automatic deamon launching of gopls.
   // See: https://github.com/neoclide/coc.nvim/commit/bdd9a9e1401fe6fdd57a9bd078e3651ecf1e0202
-  const tmpdir = (await workspace.nvim.eval('$TMPDIR')) as string;
+  const tmpdir = (await workspace.nvim.eval('$TMPDIR')) as string
 
   const server = (): Promise<ChildProcess> => {
     return new Promise((resolve) => {
@@ -93,9 +93,9 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
           cwd: workspace.cwd,
           env: { ...process.env, TMPDIR: tmpdir, ...config.goplsEnv },
         })
-      );
-    });
-  };
+      )
+    })
+  }
 
   // https://github.com/neoclide/coc.nvim/blob/master/src/language-client/client.ts#L684
   const clientOptions: LanguageClientOptions = {
@@ -105,12 +105,12 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
     disableDiagnostics: config.disable.diagnostics,
     disableCompletion: config.disable.completion,
     // TODO disableSnippetCompletion: config.disable.snippetCompletion,
-  };
+  }
 
-  const client = new LanguageClient('go', 'gopls', server, clientOptions);
+  const client = new LanguageClient('go', 'gopls', server, clientOptions)
 
   if (config.checkForUpdates !== 'disabled' && !config.goplsPath) {
-    await checkGopls(client, config.checkForUpdates);
+    await checkGopls(client, config.checkForUpdates)
   }
 
   context.subscriptions.push(
@@ -119,13 +119,13 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
     // restart gopls if options changed
     workspace.onDidChangeConfiguration(async (e) => {
       if (restartConfigs.find((k) => e.affectsConfiguration(k))) {
-        await client.stop();
-        client.restart();
+        await client.stop()
+        client.restart()
       }
     }),
 
     commands.registerCommand('go.install.gopls', () => installGopls(client))
-  );
+  )
 }
 
 async function goplsPath(goplsPath: string): Promise<string | null> {
@@ -134,18 +134,18 @@ async function goplsPath(goplsPath: string): Promise<string | null> {
       workspace.showMessage(
         `goplsPath is configured ("${goplsPath}"), but does not exist!`,
         'error'
-      );
-      return null;
+      )
+      return null
     }
 
-    return goplsPath;
+    return goplsPath
   }
 
   if (!(await installGoBin(GOPLS))) {
-    return;
+    return
   }
 
-  return goBinPath(GOPLS);
+  return goBinPath(GOPLS)
 }
 
 async function registerGoImpl(context: ExtensionContext): Promise<void> {
@@ -154,7 +154,7 @@ async function registerGoImpl(context: ExtensionContext): Promise<void> {
     commands.registerCommand('go.impl.cursor', async () =>
       generateImplStubs(await activeTextDocument())
     )
-  );
+  )
 }
 
 async function registerTest(context: ExtensionContext): Promise<void> {
@@ -172,7 +172,7 @@ async function registerTest(context: ExtensionContext): Promise<void> {
     commands.registerCommand('go.test.toggle', async () =>
       toogleTests(await activeTextDocument())
     )
-  );
+  )
 }
 
 async function registerDebug(context: ExtensionContext): Promise<void> {
@@ -180,7 +180,7 @@ async function registerDebug(context: ExtensionContext): Promise<void> {
     commands.registerCommand('go.debug.test.nearest', async () =>
       debugNearestTest(await activeTextDocument())
     )
-  );
+  )
 }
 
 async function registerTags(context: ExtensionContext): Promise<void> {
@@ -212,7 +212,7 @@ async function registerTags(context: ExtensionContext): Promise<void> {
     commands.registerCommand('go.tags.clear.line', async () =>
       clearTags(await activeTextDocument(), { selection: 'line' })
     )
-  );
+  )
 }
 
 async function registerPlaygroud(context: ExtensionContext): Promise<void> {
@@ -221,11 +221,11 @@ async function registerPlaygroud(context: ExtensionContext): Promise<void> {
     commands.registerCommand('go.playground', async () =>
       openPlayground(await activeTextDocument())
     )
-  );
+  )
 }
 
 async function registerTools(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     commands.registerCommand('go.install.tools', () => installTools())
-  );
+  )
 }

--- a/src/utils/checktag.ts
+++ b/src/utils/checktag.ts
@@ -1,35 +1,34 @@
-import fetch from 'node-fetch'
+import fetch from 'node-fetch';
 
-const releaseFilter = /^v\d+\.\d+\.\d+$/
+const releaseFilter = /^v\d+\.\d+\.\d+$/;
 
 interface Tag {
-  name: string
-  zipball_url: string
-  tarball_url: string
+  name: string;
+  zipball_url: string;
+  tarball_url: string;
   commit: {
-    sha: string
-    url: string
-  }
-  node_id: string
+    sha: string;
+    url: string;
+  };
+  node_id: string;
 }
 
-export default async function checkLatestTag(repo: string, prefixFilter?: RegExp): Promise<string> {
-  const resp = await fetch(`https://api.github.com/repos/${repo}/tags`)
-  const data = await resp.json() as Array<Tag>
+export default async function checkLatestTag(
+  repo: string,
+  prefixFilter?: RegExp
+): Promise<string> {
+  const resp = await fetch(`https://api.github.com/repos/${repo}/tags`);
+  const data = (await resp.json()) as Array<Tag>;
 
-  let tags = data.map(t => t.name)
+  let tags = data.map((t) => t.name);
 
   if (prefixFilter) {
     tags = tags
-      .filter(t => t.match(prefixFilter))
-      .map(t => t.replace(prefixFilter, ''))
+      .filter((t) => t.match(prefixFilter))
+      .map((t) => t.replace(prefixFilter, ''));
   }
 
-  tags = tags
-    .filter(t => t.match(releaseFilter))
+  tags = tags.filter((t) => t.match(releaseFilter));
 
-
-  return tags.length > 0
-    ? tags[0].replace(/^v/, '')
-    : ''
+  return tags.length > 0 ? tags[0].replace(/^v/, '') : '';
 }

--- a/src/utils/checktag.ts
+++ b/src/utils/checktag.ts
@@ -1,34 +1,34 @@
-import fetch from 'node-fetch';
+import fetch from 'node-fetch'
 
-const releaseFilter = /^v\d+\.\d+\.\d+$/;
+const releaseFilter = /^v\d+\.\d+\.\d+$/
 
 interface Tag {
-  name: string;
-  zipball_url: string;
-  tarball_url: string;
+  name: string
+  zipball_url: string
+  tarball_url: string
   commit: {
-    sha: string;
-    url: string;
-  };
-  node_id: string;
+    sha: string
+    url: string
+  }
+  node_id: string
 }
 
 export default async function checkLatestTag(
   repo: string,
   prefixFilter?: RegExp
 ): Promise<string> {
-  const resp = await fetch(`https://api.github.com/repos/${repo}/tags`);
-  const data = (await resp.json()) as Array<Tag>;
+  const resp = await fetch(`https://api.github.com/repos/${repo}/tags`)
+  const data = (await resp.json()) as Array<Tag>
 
-  let tags = data.map((t) => t.name);
+  let tags = data.map((t) => t.name)
 
   if (prefixFilter) {
     tags = tags
       .filter((t) => t.match(prefixFilter))
-      .map((t) => t.replace(prefixFilter, ''));
+      .map((t) => t.replace(prefixFilter, ''))
   }
 
-  tags = tags.filter((t) => t.match(releaseFilter));
+  tags = tags.filter((t) => t.match(releaseFilter))
 
-  return tags.length > 0 ? tags[0].replace(/^v/, '') : '';
+  return tags.length > 0 ? tags[0].replace(/^v/, '') : ''
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,196 +1,200 @@
-import path from "path"
-import os from "os"
-import { workspace } from "coc.nvim"
-import { createDir } from "./fs"
+import path from 'path';
+import os from 'os';
+import { workspace } from 'coc.nvim';
+import { createDir } from './fs';
 
 interface State {
-  storagePath?: string
+  storagePath?: string;
 }
 
-const state: State = {}
+const state: State = {};
 
 export function getConfig(): GoConfig {
-  return workspace.getConfiguration().get("go") as GoConfig
+  return workspace.getConfiguration().get('go') as GoConfig;
 }
 
 export interface GoConfig {
-  enable: boolean
-  goplsPath: string
-  goplsArgs: string[]
-  goplsEnv: { string: string }
-  goplsUseDaemon: boolean
-  goplsOptions: GoplsOptions
-  tags: GoTagsConfig
-  tests: GoTestsConfig
-  checkForUpdates: "disabled" | "inform" | "ask" | "install"
-  disable: DisableConfig
+  enable: boolean;
+  goplsPath: string;
+  goplsArgs: string[];
+  goplsEnv: { string: string };
+  goplsUseDaemon: boolean;
+  goplsOptions: GoplsOptions;
+  tags: GoTagsConfig;
+  tests: GoTestsConfig;
+  checkForUpdates: 'disabled' | 'inform' | 'ask' | 'install';
+  disable: DisableConfig;
 }
 
 export interface DisableConfig {
-  workspaceFolders: boolean
+  workspaceFolders: boolean;
   // TODO add if released: snippetCompletion: false,
   // dynamicRegister: boolean
-  diagnostics: boolean
-  completion: boolean
+  diagnostics: boolean;
+  completion: boolean;
 }
 
 export interface GoTagsConfig {
-  tags?: string
-  options?: string
-  transform?: string
-  skipUnexported?: boolean
+  tags?: string;
+  options?: string;
+  transform?: string;
+  skipUnexported?: boolean;
 }
 
 export interface GoTestsConfig {
-  generateFlags?: string[]
+  generateFlags?: string[];
 }
 
 // https://github.com/golang/tools/blob/master/gopls/doc/settings.md
 
 export interface GoplsOptions {
-
   /**
    * Default: {}
    */
-  analyses: { string: boolean }
+  analyses: { string: boolean };
 
   /**
    * Default: []
    */
-  buildFlags: string[]
+  buildFlags: string[];
 
   /**
    * Default: {}
    */
-  codelenses: { string: boolean }
+  codelenses: { string: boolean };
 
   /**
    * Default: []
    */
-  directoryFilters: string[]
+  directoryFilters: string[];
 
   /**
    * Default: {}
    */
-  env: { string: string }
+  env: { string: string };
 
   /**
    * Default: false
    */
-  gofumpt: boolean
+  gofumpt: boolean;
 
   /**
    * Default: "FullDocumentation"
    */
-  hoverKind: "FullDocumentation" | "NoDocumentation" | "SingleLine" | "Structured" | "SynopsisDocumentation"
+  hoverKind:
+    | 'FullDocumentation'
+    | 'NoDocumentation'
+    | 'SingleLine'
+    | 'Structured'
+    | 'SynopsisDocumentation';
 
   /**
    * Default: "Both"
    */
-  importShortcut: "Both" | "Definition" | "Link"
+  importShortcut: 'Both' | 'Definition' | 'Link';
 
   /**
    * Default: "pkg.go.dev"
    */
-  linkTarget: string
+  linkTarget: string;
 
   /**
    * Default: true
    */
-  linksInHover: boolean
+  linksInHover: boolean;
 
   /**
    * Default: ""
    */
-  local: string
+  local: string;
 
   /**
    * Default: "Fuzzy"
    */
-  matcher: "CaseInsensitive" | "CaseSensitive" | "Fuzzy"
+  matcher: 'CaseInsensitive' | 'CaseSensitive' | 'Fuzzy';
 
   /**
    * Default: "Fuzzy"
    */
-  symbolMatcher: "CaseInsensitive" | "CaseSensitive" | "Fuzzy"
+  symbolMatcher: 'CaseInsensitive' | 'CaseSensitive' | 'Fuzzy';
 
   /**
    * Default: "Dynamic"
    */
-  symbolStyle: "Dynamic" | "Full" | "Package"
+  symbolStyle: 'Dynamic' | 'Full' | 'Package';
 
   /**
    * Default: false
    */
-  usePlaceholders: boolean
-
-  /**
-   * Experimental!
-   * Default: false
-   */
-  allowImplicitNetworkAccess: boolean
+  usePlaceholders: boolean;
 
   /**
    * Experimental!
    * Default: false
    */
-  allowModfileModifications: boolean
+  allowImplicitNetworkAccess: boolean;
+
+  /**
+   * Experimental!
+   * Default: false
+   */
+  allowModfileModifications: boolean;
 
   /**
    * Experimental!
    * Default: {}
    */
-  annotations: { string: boolean }
+  annotations: { string: boolean };
 
   /**
    * Experimental!
    * Default: true
    */
-  expandWorkspaceToModule: boolean
+  expandWorkspaceToModule: boolean;
 
   /**
    * Experimental!
    * Default: "250ms"
    */
-  experimentalDiagnosticsDelay: string
+  experimentalDiagnosticsDelay: string;
 
   /**
    * Experimental!
    * Default: true
    */
-  experimentalPackageCacheKey: boolean
+  experimentalPackageCacheKey: boolean;
 
   /**
    * Experimental!
    * Default: false
    */
-  experimentalWorkspaceModule: boolean
+  experimentalWorkspaceModule: boolean;
 
   /**
    * Experimental!
    * Default: false
    */
-  semanticTokens: boolean
+  semanticTokens: boolean;
 
   /**
    * Experimental!
    * Default: false
    */
-  staticcheck: boolean
+  staticcheck: boolean;
 }
 
 export function setStoragePath(dir: string): void {
-  state.storagePath = dir
+  state.storagePath = dir;
 }
 
 export async function configDir(...names: string[]): Promise<string> {
   const storage =
-    state.storagePath || path.join(os.homedir(), ".config", "coc", "go")
+    state.storagePath || path.join(os.homedir(), '.config', 'coc', 'go');
 
-  const dir = path.join(storage, ...names)
+  const dir = path.join(storage, ...names);
 
   return new Promise((resolve): void => {
-    createDir(dir)
-    resolve(dir)
-  })
+    createDir(dir);
+    resolve(dir);
+  });
 }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,48 +1,48 @@
-import path from 'path';
-import os from 'os';
-import { workspace } from 'coc.nvim';
-import { createDir } from './fs';
+import path from 'path'
+import os from 'os'
+import { workspace } from 'coc.nvim'
+import { createDir } from './fs'
 
 interface State {
-  storagePath?: string;
+  storagePath?: string
 }
 
-const state: State = {};
+const state: State = {}
 
 export function getConfig(): GoConfig {
-  return workspace.getConfiguration().get('go') as GoConfig;
+  return workspace.getConfiguration().get('go') as GoConfig
 }
 
 export interface GoConfig {
-  enable: boolean;
-  goplsPath: string;
-  goplsArgs: string[];
-  goplsEnv: { string: string };
-  goplsUseDaemon: boolean;
-  goplsOptions: GoplsOptions;
-  tags: GoTagsConfig;
-  tests: GoTestsConfig;
-  checkForUpdates: 'disabled' | 'inform' | 'ask' | 'install';
-  disable: DisableConfig;
+  enable: boolean
+  goplsPath: string
+  goplsArgs: string[]
+  goplsEnv: { string: string }
+  goplsUseDaemon: boolean
+  goplsOptions: GoplsOptions
+  tags: GoTagsConfig
+  tests: GoTestsConfig
+  checkForUpdates: 'disabled' | 'inform' | 'ask' | 'install'
+  disable: DisableConfig
 }
 
 export interface DisableConfig {
-  workspaceFolders: boolean;
+  workspaceFolders: boolean
   // TODO add if released: snippetCompletion: false,
   // dynamicRegister: boolean
-  diagnostics: boolean;
-  completion: boolean;
+  diagnostics: boolean
+  completion: boolean
 }
 
 export interface GoTagsConfig {
-  tags?: string;
-  options?: string;
-  transform?: string;
-  skipUnexported?: boolean;
+  tags?: string
+  options?: string
+  transform?: string
+  skipUnexported?: boolean
 }
 
 export interface GoTestsConfig {
-  generateFlags?: string[];
+  generateFlags?: string[]
 }
 
 // https://github.com/golang/tools/blob/master/gopls/doc/settings.md
@@ -51,32 +51,32 @@ export interface GoplsOptions {
   /**
    * Default: {}
    */
-  analyses: { string: boolean };
+  analyses: { string: boolean }
 
   /**
    * Default: []
    */
-  buildFlags: string[];
+  buildFlags: string[]
 
   /**
    * Default: {}
    */
-  codelenses: { string: boolean };
+  codelenses: { string: boolean }
 
   /**
    * Default: []
    */
-  directoryFilters: string[];
+  directoryFilters: string[]
 
   /**
    * Default: {}
    */
-  env: { string: string };
+  env: { string: string }
 
   /**
    * Default: false
    */
-  gofumpt: boolean;
+  gofumpt: boolean
 
   /**
    * Default: "FullDocumentation"
@@ -86,115 +86,115 @@ export interface GoplsOptions {
     | 'NoDocumentation'
     | 'SingleLine'
     | 'Structured'
-    | 'SynopsisDocumentation';
+    | 'SynopsisDocumentation'
 
   /**
    * Default: "Both"
    */
-  importShortcut: 'Both' | 'Definition' | 'Link';
+  importShortcut: 'Both' | 'Definition' | 'Link'
 
   /**
    * Default: "pkg.go.dev"
    */
-  linkTarget: string;
+  linkTarget: string
 
   /**
    * Default: true
    */
-  linksInHover: boolean;
+  linksInHover: boolean
 
   /**
    * Default: ""
    */
-  local: string;
+  local: string
 
   /**
    * Default: "Fuzzy"
    */
-  matcher: 'CaseInsensitive' | 'CaseSensitive' | 'Fuzzy';
+  matcher: 'CaseInsensitive' | 'CaseSensitive' | 'Fuzzy'
 
   /**
    * Default: "Fuzzy"
    */
-  symbolMatcher: 'CaseInsensitive' | 'CaseSensitive' | 'Fuzzy';
+  symbolMatcher: 'CaseInsensitive' | 'CaseSensitive' | 'Fuzzy'
 
   /**
    * Default: "Dynamic"
    */
-  symbolStyle: 'Dynamic' | 'Full' | 'Package';
+  symbolStyle: 'Dynamic' | 'Full' | 'Package'
 
   /**
    * Default: false
    */
-  usePlaceholders: boolean;
-
-  /**
-   * Experimental!
-   * Default: false
-   */
-  allowImplicitNetworkAccess: boolean;
+  usePlaceholders: boolean
 
   /**
    * Experimental!
    * Default: false
    */
-  allowModfileModifications: boolean;
+  allowImplicitNetworkAccess: boolean
+
+  /**
+   * Experimental!
+   * Default: false
+   */
+  allowModfileModifications: boolean
 
   /**
    * Experimental!
    * Default: {}
    */
-  annotations: { string: boolean };
+  annotations: { string: boolean }
 
   /**
    * Experimental!
    * Default: true
    */
-  expandWorkspaceToModule: boolean;
+  expandWorkspaceToModule: boolean
 
   /**
    * Experimental!
    * Default: "250ms"
    */
-  experimentalDiagnosticsDelay: string;
+  experimentalDiagnosticsDelay: string
 
   /**
    * Experimental!
    * Default: true
    */
-  experimentalPackageCacheKey: boolean;
+  experimentalPackageCacheKey: boolean
 
   /**
    * Experimental!
    * Default: false
    */
-  experimentalWorkspaceModule: boolean;
+  experimentalWorkspaceModule: boolean
 
   /**
    * Experimental!
    * Default: false
    */
-  semanticTokens: boolean;
+  semanticTokens: boolean
 
   /**
    * Experimental!
    * Default: false
    */
-  staticcheck: boolean;
+  staticcheck: boolean
 }
 
 export function setStoragePath(dir: string): void {
-  state.storagePath = dir;
+  state.storagePath = dir
 }
 
 export async function configDir(...names: string[]): Promise<string> {
   const storage =
-    state.storagePath || path.join(os.homedir(), '.config', 'coc', 'go');
+    state.storagePath || path.join(os.homedir(), '.config', 'coc', 'go')
 
-  const dir = path.join(storage, ...names);
+  const dir = path.join(storage, ...names)
 
   return new Promise((resolve): void => {
-    createDir(dir);
-    resolve(dir);
-  });
+    createDir(dir)
+    resolve(dir)
+  })
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,55 +1,55 @@
-import { Document, workspace } from 'coc.nvim';
-import { TextDocument } from 'vscode-languageserver-protocol';
-import { isTest } from './tests';
+import { Document, workspace } from 'coc.nvim'
+import { TextDocument } from 'vscode-languageserver-protocol'
+import { isTest } from './tests'
 
 export const findNearestTest = async (): Promise<string | undefined> => {
-  const doc = await workspace.document;
-  const { nvim } = workspace;
-  const lineNumber = ((await nvim.call('line', '.')) as number) - 1;
+  const doc = await workspace.document
+  const { nvim } = workspace
+  const lineNumber = ((await nvim.call('line', '.')) as number) - 1
 
-  return findTestName(doc, lineNumber);
-};
+  return findTestName(doc, lineNumber)
+}
 
 const findTestName = (doc: Document, lineNumber: number) => {
   if (lineNumber < 0) {
-    return undefined;
+    return undefined
   }
 
-  const testName = extractTestNameFromLine(doc.getline(lineNumber) ?? '');
+  const testName = extractTestNameFromLine(doc.getline(lineNumber) ?? '')
   if (testName) {
-    return testName;
+    return testName
   }
 
-  return findTestName(doc, lineNumber - 1);
-};
+  return findTestName(doc, lineNumber - 1)
+}
 
 const extractTestNameFromLine = (line: string) => {
-  const matchedArray = line.match(/^\s*func\s*(Test[^(]+)/);
+  const matchedArray = line.match(/^\s*func\s*([tT]est[^(]+)/)
   if (matchedArray != undefined) {
-    return matchedArray[1].trimEnd();
+    return matchedArray[1].trimEnd()
   }
-  return undefined;
-};
+  return undefined
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function debugNearestTest(document: TextDocument): Promise<void> {
   if (!isTest(document)) {
-    workspace.showMessage('Document is not a test file', 'error');
-    return;
+    workspace.showMessage('Document is not a test file', 'error')
+    return
   }
 
   const name = workspace
     .getConfiguration('go.debug.vimspector.configuration')
-    .get<string>('name');
-  const testIdentifier = await findNearestTest();
+    .get<string>('name')
+  const testIdentifier = await findNearestTest()
 
   if (testIdentifier) {
-    console.info(`debuging test: ${testIdentifier}`);
+    console.info(`debuging test: ${testIdentifier}`)
     const configuration = {
       configuration: name,
       TestIdentifier: testIdentifier,
-    };
-    await workspace.nvim.call('vimspector#LaunchWithSettings', configuration);
+    }
+    await workspace.nvim.call('vimspector#LaunchWithSettings', configuration)
   }
 }

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -1,0 +1,55 @@
+import { Document, workspace } from 'coc.nvim';
+import { TextDocument } from 'vscode-languageserver-protocol';
+import { isTest } from './tests';
+
+export const findNearestTest = async (): Promise<string | undefined> => {
+  const doc = await workspace.document;
+  const { nvim } = workspace;
+  const lineNumber = ((await nvim.call('line', '.')) as number) - 1;
+
+  return findTestName(doc, lineNumber);
+};
+
+const findTestName = (doc: Document, lineNumber: number) => {
+  if (lineNumber < 0) {
+    return undefined;
+  }
+
+  const testName = extractTestNameFromLine(doc.getline(lineNumber) ?? '');
+  if (testName) {
+    return testName;
+  }
+
+  return findTestName(doc, lineNumber - 1);
+};
+
+const extractTestNameFromLine = (line: string) => {
+  const matchedArray = line.match(/^\s*func\s*(Test[^(]+)/);
+  if (matchedArray != undefined) {
+    return matchedArray[1].trimEnd();
+  }
+  return undefined;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+export async function debugNearestTest(document: TextDocument): Promise<void> {
+  if (!isTest(document)) {
+    workspace.showMessage('Document is not a test file', 'error');
+    return;
+  }
+
+  const name = workspace
+    .getConfiguration('go.debug.vimspector.configuration')
+    .get<string>('name');
+  const testIdentifier = await findNearestTest();
+
+  if (testIdentifier) {
+    console.info(`debuging test: ${testIdentifier}`);
+    const configuration = {
+      configuration: name,
+      TestIdentifier: testIdentifier,
+    };
+    await workspace.nvim.call('vimspector#LaunchWithSettings', configuration);
+  }
+}

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -1,36 +1,36 @@
-import tmp, { DirResult } from 'tmp';
-import assert from 'assert';
-import path from 'path';
-import fs from 'fs';
-import { createDir } from './fs';
+import tmp, { DirResult } from 'tmp'
+import assert from 'assert'
+import path from 'path'
+import fs from 'fs'
+import { createDir } from './fs'
 
 describe('createDir()', () => {
-  let tmpDir: DirResult;
+  let tmpDir: DirResult
 
-  const joinPath = (...parts: string[]) => path.join(tmpDir.name, ...parts);
+  const joinPath = (...parts: string[]) => path.join(tmpDir.name, ...parts)
 
-  beforeEach(() => (tmpDir = tmp.dirSync({ unsafeCleanup: true })));
-  afterEach(() => tmpDir.removeCallback());
+  beforeEach(() => (tmpDir = tmp.dirSync({ unsafeCleanup: true })))
+  afterEach(() => tmpDir.removeCallback())
 
   it('should create a directory', () => {
-    const dirPath = joinPath('test');
+    const dirPath = joinPath('test')
 
-    createDir(dirPath);
+    createDir(dirPath)
 
-    assert.ok(fs.existsSync(dirPath));
-  });
+    assert.ok(fs.existsSync(dirPath))
+  })
 
   it('should create nested directories', () => {
-    const dirPath = joinPath('test', 'foo', 'bar');
+    const dirPath = joinPath('test', 'foo', 'bar')
 
-    createDir(dirPath);
+    createDir(dirPath)
 
-    assert.ok(fs.existsSync(dirPath));
-  });
+    assert.ok(fs.existsSync(dirPath))
+  })
 
   it('should not fail if directory exists', () => {
-    createDir(tmpDir.name);
+    createDir(tmpDir.name)
 
-    assert.ok(fs.existsSync(tmpDir.name));
-  });
-});
+    assert.ok(fs.existsSync(tmpDir.name))
+  })
+})

--- a/src/utils/fs.test.ts
+++ b/src/utils/fs.test.ts
@@ -1,38 +1,36 @@
-import tmp, { DirResult } from 'tmp'
-import assert from 'assert'
-import path from 'path'
-import fs from 'fs'
-import { createDir } from './fs'
+import tmp, { DirResult } from 'tmp';
+import assert from 'assert';
+import path from 'path';
+import fs from 'fs';
+import { createDir } from './fs';
 
 describe('createDir()', () => {
-  let tmpDir: DirResult
+  let tmpDir: DirResult;
 
-  const joinPath = (...parts: string[]) => path.join(tmpDir.name, ...parts)
+  const joinPath = (...parts: string[]) => path.join(tmpDir.name, ...parts);
 
-
-  beforeEach(() => tmpDir = tmp.dirSync({ unsafeCleanup: true }))
-  afterEach(() => tmpDir.removeCallback())
+  beforeEach(() => (tmpDir = tmp.dirSync({ unsafeCleanup: true })));
+  afterEach(() => tmpDir.removeCallback());
 
   it('should create a directory', () => {
-    const dirPath = joinPath('test')
+    const dirPath = joinPath('test');
 
-    createDir(dirPath)
+    createDir(dirPath);
 
-    assert.ok(fs.existsSync(dirPath))
-  })
+    assert.ok(fs.existsSync(dirPath));
+  });
 
   it('should create nested directories', () => {
-    const dirPath = joinPath('test', 'foo', 'bar')
+    const dirPath = joinPath('test', 'foo', 'bar');
 
-    createDir(dirPath)
+    createDir(dirPath);
 
-    assert.ok(fs.existsSync(dirPath))
-  })
+    assert.ok(fs.existsSync(dirPath));
+  });
 
   it('should not fail if directory exists', () => {
-    createDir(tmpDir.name)
+    createDir(tmpDir.name);
 
-    assert.ok(fs.existsSync(tmpDir.name))
-  })
-})
-
+    assert.ok(fs.existsSync(tmpDir.name));
+  });
+});

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,12 +1,12 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'fs'
+import path from 'path'
 
 export function createDir(dirPath: string): void {
   if (fs.existsSync(dirPath)) {
-    return;
+    return
   }
 
-  createDir(path.dirname(dirPath));
+  createDir(path.dirname(dirPath))
 
-  fs.mkdirSync(dirPath);
+  fs.mkdirSync(dirPath)
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,13 +1,12 @@
-import fs from 'fs'
-import path from 'path'
+import fs from 'fs';
+import path from 'path';
 
 export function createDir(dirPath: string): void {
   if (fs.existsSync(dirPath)) {
-    return
+    return;
   }
 
-  createDir(path.dirname(dirPath))
+  createDir(path.dirname(dirPath));
 
-  fs.mkdirSync(dirPath)
+  fs.mkdirSync(dirPath);
 }
-

--- a/src/utils/impl.ts
+++ b/src/utils/impl.ts
@@ -1,31 +1,31 @@
-import { workspace } from 'coc.nvim';
-import { TextDocument, TextEdit } from 'vscode-languageserver-protocol';
-import { IMPL } from '../binaries';
-import { execTool } from './tools';
+import { workspace } from 'coc.nvim'
+import { TextDocument, TextEdit } from 'vscode-languageserver-protocol'
+import { IMPL } from '../binaries'
+import { execTool } from './tools'
 
-const interfaceRegex = /^(\w+ \*?\w+ )?([\w./]+)$/;
+const interfaceRegex = /^(\w+ \*?\w+ )?([\w./]+)$/
 
 export async function generateImplStubs(document: TextDocument): Promise<void> {
   try {
     const implInput = await workspace.requestInput(
       'Enter receiver and interface [f *File io.Closer]'
-    );
+    )
 
     if (implInput == null) {
-      workspace.showMessage('No input detected! Aborting.', 'warning');
-      return;
+      workspace.showMessage('No input detected! Aborting.', 'warning')
+      return
     }
 
-    const matches = implInput.match(interfaceRegex);
+    const matches = implInput.match(interfaceRegex)
     if (!matches) {
-      throw Error(`Cannot parse input: ${implInput}`);
+      throw Error(`Cannot parse input: ${implInput}`)
     }
 
-    const edit = await runGoImpl(document, [matches[1], matches[2]]);
+    const edit = await runGoImpl(document, [matches[1], matches[2]])
 
-    await workspace.applyEdit({ changes: { [document.uri]: [edit] } });
+    await workspace.applyEdit({ changes: { [document.uri]: [edit] } })
   } catch (error) {
-    workspace.showMessage(error, 'error');
+    workspace.showMessage(error, 'error')
   }
 }
 
@@ -33,13 +33,13 @@ async function runGoImpl(
   document: TextDocument,
   args: string[]
 ): Promise<TextEdit> {
-  const stdout = await execTool(IMPL, args);
+  const stdout = await execTool(IMPL, args)
 
-  const { line } = await workspace.getCursorPosition();
-  const insertPos = { line: line + 1, character: 0 };
+  const { line } = await workspace.getCursorPosition()
+  const insertPos = { line: line + 1, character: 0 }
 
-  const lineText = await workspace.getLine(document.uri, line);
-  const newText = lineText.trim() === '' ? stdout : `\n${stdout}`;
+  const lineText = await workspace.getLine(document.uri, line)
+  const newText = lineText.trim() === '' ? stdout : `\n${stdout}`
 
   return {
     range: {
@@ -47,5 +47,5 @@ async function runGoImpl(
       end: insertPos,
     },
     newText,
-  };
+  }
 }

--- a/src/utils/impl.ts
+++ b/src/utils/impl.ts
@@ -1,50 +1,51 @@
-import { workspace } from 'coc.nvim'
-import { TextDocument, TextEdit } from 'vscode-languageserver-protocol'
-import { IMPL } from '../binaries'
-import {execTool } from './tools'
+import { workspace } from 'coc.nvim';
+import { TextDocument, TextEdit } from 'vscode-languageserver-protocol';
+import { IMPL } from '../binaries';
+import { execTool } from './tools';
 
-const interfaceRegex = /^(\w+ \*?\w+ )?([\w./]+)$/
+const interfaceRegex = /^(\w+ \*?\w+ )?([\w./]+)$/;
 
 export async function generateImplStubs(document: TextDocument): Promise<void> {
   try {
-    const implInput = await workspace.requestInput("Enter receiver and interface [f *File io.Closer]")
+    const implInput = await workspace.requestInput(
+      'Enter receiver and interface [f *File io.Closer]'
+    );
 
     if (implInput == null) {
-      workspace.showMessage("No input detected! Aborting.", "warning")
-      return
+      workspace.showMessage('No input detected! Aborting.', 'warning');
+      return;
     }
 
-    const matches = implInput.match(interfaceRegex)
+    const matches = implInput.match(interfaceRegex);
     if (!matches) {
-      throw Error(`Cannot parse input: ${implInput}`)
+      throw Error(`Cannot parse input: ${implInput}`);
     }
 
-    const edit = await runGoImpl(document, [matches[1], matches[2]])
+    const edit = await runGoImpl(document, [matches[1], matches[2]]);
 
-    await workspace.applyEdit({ changes: { [document.uri]: [edit] } })
+    await workspace.applyEdit({ changes: { [document.uri]: [edit] } });
   } catch (error) {
-    workspace.showMessage(error, "error")
+    workspace.showMessage(error, 'error');
   }
 }
 
-async function runGoImpl(document: TextDocument, args: string[]): Promise<TextEdit> {
+async function runGoImpl(
+  document: TextDocument,
+  args: string[]
+): Promise<TextEdit> {
+  const stdout = await execTool(IMPL, args);
 
-  const stdout = await execTool(IMPL, args)
+  const { line } = await workspace.getCursorPosition();
+  const insertPos = { line: line + 1, character: 0 };
 
-  const { line } = await workspace.getCursorPosition()
-  const insertPos = { line: line + 1, character: 0 }
-
-  const lineText = await workspace.getLine(document.uri, line)
-  const newText = lineText.trim() === ''
-    ? stdout
-    : `\n${stdout}`
+  const lineText = await workspace.getLine(document.uri, line);
+  const newText = lineText.trim() === '' ? stdout : `\n${stdout}`;
 
   return {
     range: {
       start: insertPos,
-      end: insertPos
+      end: insertPos,
     },
-    newText
-  }
+    newText,
+  };
 }
-

--- a/src/utils/modify-tags.ts
+++ b/src/utils/modify-tags.ts
@@ -1,158 +1,195 @@
-import { Position, TextDocument, TextEdit } from 'vscode-languageserver-protocol'
-import { workspace } from 'coc.nvim'
-import { URI } from 'vscode-uri'
+import {
+  Position,
+  TextDocument,
+  TextEdit,
+} from 'vscode-languageserver-protocol';
+import { workspace } from 'coc.nvim';
+import { URI } from 'vscode-uri';
 
-import { GoTagsConfig } from './config'
-import { execTool } from './tools'
-import { GOMODIFYTAGS } from '../binaries'
+import { GoTagsConfig } from './config';
+import { execTool } from './tools';
+import { GOMODIFYTAGS } from '../binaries';
 
 interface Params {
-  prompt?: boolean
-  tags?: string[]
-  selection?: "line" | "struct"
+  prompt?: boolean;
+  tags?: string[];
+  selection?: 'line' | 'struct';
 }
 
 interface ClearParams {
-  selection?: "line" | "struct"
+  selection?: 'line' | 'struct';
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export async function addTags(document: TextDocument, params: Params = {}): Promise<void> {
-  const config = workspace.getConfiguration().get('go.tags', {}) as GoTagsConfig
+export async function addTags(
+  document: TextDocument,
+  params: Params = {}
+): Promise<void> {
+  const config = workspace
+    .getConfiguration()
+    .get('go.tags', {}) as GoTagsConfig;
 
-  let tags = (params.tags && params.tags.length > 0)
-    ? params.tags.join(',')
-    : (config.tags || 'json')
-  let options = (config.options || config.options === "")
-    ? config.options
-    : 'json=omitempty'
-  const transform = (config.transform || "snakecase")
-  const skipUnexported = config.skipUnexported
+  let tags =
+    params.tags && params.tags.length > 0
+      ? params.tags.join(',')
+      : config.tags || 'json';
+  let options =
+    config.options || config.options === '' ? config.options : 'json=omitempty';
+  const transform = config.transform || 'snakecase';
+  const skipUnexported = config.skipUnexported;
 
-  let cursor
+  let cursor;
   if (params.prompt) {
-    cursor = await workspace.getCursorPosition()
-    tags = await workspace.requestInput('Enter comma separated tag names', tags)
+    cursor = await workspace.getCursorPosition();
+    tags = await workspace.requestInput(
+      'Enter comma separated tag names',
+      tags
+    );
     if (!tags) {
-      return
+      return;
     }
 
-    options = await workspace.requestInput('Enter comma separated options', options)
+    options = await workspace.requestInput(
+      'Enter comma separated options',
+      options
+    );
   }
 
   const args = [
-    '-add-tags', tags.replace(/ +/g, ''),
+    '-add-tags',
+    tags.replace(/ +/g, ''),
     '-override',
-    '-add-options', (options || ""),
-    '-transform', transform,
-    ...(await offsetArgs(document, (params.selection || "struct"), cursor))
-  ]
+    '-add-options',
+    options || '',
+    '-transform',
+    transform,
+    ...(await offsetArgs(document, params.selection || 'struct', cursor)),
+  ];
   if (skipUnexported) {
-    args.push('--skip-unexported')
+    args.push('--skip-unexported');
   }
-  await runGomodifytags(document, args)
+  await runGomodifytags(document, args);
 }
 
-export async function removeTags(document: TextDocument, params: Params = {}): Promise<void> {
-  const config = workspace.getConfiguration().get('go.tags', {}) as GoTagsConfig
+export async function removeTags(
+  document: TextDocument,
+  params: Params = {}
+): Promise<void> {
+  const config = workspace
+    .getConfiguration()
+    .get('go.tags', {}) as GoTagsConfig;
 
-  let tags = (params.tags && params.tags.length > 0)
-    ? params.tags.join(',')
-    : (config.tags || 'json')
+  let tags =
+    params.tags && params.tags.length > 0
+      ? params.tags.join(',')
+      : config.tags || 'json';
 
-  let cursor
+  let cursor;
   if (params.prompt) {
-    cursor = await workspace.getCursorPosition()
-    tags = await workspace.requestInput('Enter comma separated tag names', tags)
+    cursor = await workspace.getCursorPosition();
+    tags = await workspace.requestInput(
+      'Enter comma separated tag names',
+      tags
+    );
     if (!tags) {
-      return
+      return;
     }
   }
 
   await runGomodifytags(document, [
-    '-remove-tags', (tags || "json"),
+    '-remove-tags',
+    tags || 'json',
     '-clear-options',
-    ...(await offsetArgs(document, (params.selection || "struct"), cursor))
-  ])
+    ...(await offsetArgs(document, params.selection || 'struct', cursor)),
+  ]);
 }
 
-export async function clearTags(document: TextDocument, params: ClearParams = {}): Promise<void> {
+export async function clearTags(
+  document: TextDocument,
+  params: ClearParams = {}
+): Promise<void> {
   await runGomodifytags(document, [
     '-clear-tags',
     '-clear-options',
-    ...(await offsetArgs(document, (params.selection || "struct")))
-  ])
+    ...(await offsetArgs(document, params.selection || 'struct')),
+  ]);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-async function runGomodifytags(document: TextDocument, args: string[]): Promise<void> {
+async function runGomodifytags(
+  document: TextDocument,
+  args: string[]
+): Promise<void> {
+  const fileName = URI.parse(document.uri).fsPath;
 
-  const fileName = URI.parse(document.uri).fsPath
+  args.push('-modified', '-file', fileName, '-format', 'json');
 
-  args.push(
-    '-modified',
-    '-file', fileName,
-    '-format', 'json'
-  )
+  const input = fileArchive(fileName, document.getText());
+  const edit = await execGomodifytags(args, input);
 
-
-  const input = fileArchive(fileName, document.getText())
-  const edit = await execGomodifytags(args, input)
-
-  await workspace.applyEdit({ changes: { [document.uri]: [edit] } })
+  await workspace.applyEdit({ changes: { [document.uri]: [edit] } });
 }
 
 // Interface for the output from gomodifytags
 interface GomodifytagsOutput {
-  start: number
-  end: number
-  lines: string[]
+  start: number;
+  end: number;
+  lines: string[];
 }
 
-async function execGomodifytags(args: string[], input: string): Promise<TextEdit> {
-
+async function execGomodifytags(
+  args: string[],
+  input: string
+): Promise<TextEdit> {
   try {
-    const stdout = await execTool(GOMODIFYTAGS, args, input)
-    const mods = JSON.parse(stdout) as GomodifytagsOutput
+    const stdout = await execTool(GOMODIFYTAGS, args, input);
+    const mods = JSON.parse(stdout) as GomodifytagsOutput;
 
     return {
       range: {
         start: { line: mods.start - 1, character: 0 },
-        end: { line: mods.end, character: 0 }
+        end: { line: mods.end, character: 0 },
       },
-      newText: mods.lines.join("\n") + "\n"
-    }
-
+      newText: mods.lines.join('\n') + '\n',
+    };
   } catch (err) {
-    workspace.showMessage(`Cannot modify tags: ${err}`, 'error')
-    throw err
+    workspace.showMessage(`Cannot modify tags: ${err}`, 'error');
+    throw err;
   }
 }
 
 function fileArchive(fileName: string, fileContents: string): string {
-  return fileName + '\n' + Buffer.byteLength(fileContents, 'utf8') + '\n' + fileContents
+  return (
+    fileName +
+    '\n' +
+    Buffer.byteLength(fileContents, 'utf8') +
+    '\n' +
+    fileContents
+  );
 }
 
 // https://github.com/microsoft/vscode-go/blob/master/src/util.ts#L84
 function byteOffsetAt(document: TextDocument, position: Position): string {
-  const offset = document.offsetAt(position)
-  const text = document.getText()
-  return Buffer.byteLength(text.substr(0, offset)).toString()
+  const offset = document.offsetAt(position);
+  const text = document.getText();
+  return Buffer.byteLength(text.substr(0, offset)).toString();
 }
 
-async function offsetArgs(document: TextDocument, selection: "struct" | "line", cursor = null): Promise<string[]> {
+async function offsetArgs(
+  document: TextDocument,
+  selection: 'struct' | 'line',
+  cursor = null
+): Promise<string[]> {
+  cursor = cursor || (await workspace.getCursorPosition());
 
-  cursor = cursor || await workspace.getCursorPosition()
-
-  workspace.showMessage(`selection = ${selection}`)
+  workspace.showMessage(`selection = ${selection}`);
 
   switch (selection) {
-    case "struct":
-      return ['-offset', byteOffsetAt(document, cursor)]
-    case "line":
-      return ['-line', String(cursor.line + 1)]
+    case 'struct':
+      return ['-offset', byteOffsetAt(document, cursor)];
+    case 'line':
+      return ['-line', String(cursor.line + 1)];
   }
 }
-

--- a/src/utils/playground.ts
+++ b/src/utils/playground.ts
@@ -1,24 +1,19 @@
-import { TextDocument } from 'vscode-languageserver-protocol'
-import { workspace } from 'coc.nvim'
-import { execTool } from './tools'
-import { GOPLAY } from '../binaries'
+import { TextDocument } from 'vscode-languageserver-protocol';
+import { workspace } from 'coc.nvim';
+import { execTool } from './tools';
+import { GOPLAY } from '../binaries';
 
 export async function openPlayground(document: TextDocument): Promise<boolean> {
-
-  return runGoplay(document.getText())
+  return runGoplay(document.getText());
 }
 
 async function runGoplay(code: string): Promise<boolean> {
-
   try {
-    const stdout = await execTool(GOPLAY, ['-'], code)
-    workspace.showMessage(stdout)
-    return true
-
+    const stdout = await execTool(GOPLAY, ['-'], code);
+    workspace.showMessage(stdout);
+    return true;
   } catch (err) {
-    workspace.showMessage(`${err}`, "error")
-    return false
+    workspace.showMessage(`${err}`, 'error');
+    return false;
   }
-
 }
-

--- a/src/utils/playground.ts
+++ b/src/utils/playground.ts
@@ -1,19 +1,19 @@
-import { TextDocument } from 'vscode-languageserver-protocol';
-import { workspace } from 'coc.nvim';
-import { execTool } from './tools';
-import { GOPLAY } from '../binaries';
+import { TextDocument } from 'vscode-languageserver-protocol'
+import { workspace } from 'coc.nvim'
+import { execTool } from './tools'
+import { GOPLAY } from '../binaries'
 
 export async function openPlayground(document: TextDocument): Promise<boolean> {
-  return runGoplay(document.getText());
+  return runGoplay(document.getText())
 }
 
 async function runGoplay(code: string): Promise<boolean> {
   try {
-    const stdout = await execTool(GOPLAY, ['-'], code);
-    workspace.showMessage(stdout);
-    return true;
+    const stdout = await execTool(GOPLAY, ['-'], code)
+    workspace.showMessage(stdout)
+    return true
   } catch (err) {
-    workspace.showMessage(`${err}`, 'error');
-    return false;
+    workspace.showMessage(`${err}`, 'error')
+    return false
   }
 }

--- a/src/utils/tests.test.ts
+++ b/src/utils/tests.test.ts
@@ -1,8 +1,7 @@
-import assert from 'assert'
-import { extractFunctionName } from "./tests"
+import assert from 'assert';
+import { extractFunctionName } from './tests';
 
 describe('extractFunctionName()', () => {
-
   const cases = [
     ['', null],
     ['\tfuncFoo()', null],
@@ -10,12 +9,11 @@ describe('extractFunctionName()', () => {
     ['func Foo() string {', 'Foo'],
     ['func Foo(str string) string {', 'Foo'],
     ['func (b *Bar) Foo(str string) string {', 'Foo'],
-  ]
+  ];
 
   cases.forEach(([line, name]) => {
     it(`should extract ${JSON.stringify(name)} from "${line}"`, () => {
-      assert.equal(name, extractFunctionName(line))
-    })
-  })
-
-})
+      assert.equal(name, extractFunctionName(line));
+    });
+  });
+});

--- a/src/utils/tests.test.ts
+++ b/src/utils/tests.test.ts
@@ -1,5 +1,5 @@
-import assert from 'assert';
-import { extractFunctionName } from './tests';
+import assert from 'assert'
+import { extractFunctionName } from './tests'
 
 describe('extractFunctionName()', () => {
   const cases = [
@@ -9,11 +9,11 @@ describe('extractFunctionName()', () => {
     ['func Foo() string {', 'Foo'],
     ['func Foo(str string) string {', 'Foo'],
     ['func (b *Bar) Foo(str string) string {', 'Foo'],
-  ];
+  ]
 
   cases.forEach(([line, name]) => {
     it(`should extract ${JSON.stringify(name)} from "${line}"`, () => {
-      assert.equal(name, extractFunctionName(line));
-    });
-  });
-});
+      assert.equal(name, extractFunctionName(line))
+    })
+  })
+})

--- a/src/utils/tests.ts
+++ b/src/utils/tests.ts
@@ -1,78 +1,78 @@
-import { workspace } from 'coc.nvim';
-import { URI } from 'vscode-uri';
-import { TextDocument } from 'vscode-languageserver-protocol';
-import { execTool } from './tools';
-import { GOTESTS } from '../binaries';
-import { GoTestsConfig } from './config';
+import { workspace } from 'coc.nvim'
+import { URI } from 'vscode-uri'
+import { TextDocument } from 'vscode-languageserver-protocol'
+import { execTool } from './tools'
+import { GOTESTS } from '../binaries'
+import { GoTestsConfig } from './config'
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export async function generateTestsAll(document: TextDocument): Promise<void> {
   if (isTest(document)) {
-    workspace.showMessage('Document is a test file', 'error');
-    return;
+    workspace.showMessage('Document is a test file', 'error')
+    return
   }
-  (await runGotests(document, ['-all'])) && (await openTests(document));
+  ;(await runGotests(document, ['-all'])) && (await openTests(document))
 }
 
 export async function generateTestsExported(
   document: TextDocument
 ): Promise<void> {
   if (isTest(document)) {
-    workspace.showMessage('Document is a test file', 'error');
-    return;
+    workspace.showMessage('Document is a test file', 'error')
+    return
   }
-  (await runGotests(document, ['-exported'])) && (await openTests(document));
+  ;(await runGotests(document, ['-exported'])) && (await openTests(document))
 }
 
 export async function generateTestsFunction(
   document: TextDocument
 ): Promise<void> {
   if (isTest(document)) {
-    workspace.showMessage('Document is a test file', 'error');
-    return;
+    workspace.showMessage('Document is a test file', 'error')
+    return
   }
 
-  const { line } = await workspace.getCursorPosition();
+  const { line } = await workspace.getCursorPosition()
   const text = await document.getText({
     start: { line, character: 0 },
     end: { line, character: Infinity },
-  });
+  })
 
-  workspace.showMessage(text);
+  workspace.showMessage(text)
 
-  const funcName = extractFunctionName(text);
+  const funcName = extractFunctionName(text)
   if (!funcName) {
-    workspace.showMessage('No function found', 'error');
-    return;
+    workspace.showMessage('No function found', 'error')
+    return
   }
 
-  (await runGotests(document, ['-only', `^${funcName}$`])) &&
-    (await openTests(document));
+  ;(await runGotests(document, ['-only', `^${funcName}$`])) &&
+    (await openTests(document))
 }
 
 export async function toogleTests(document: TextDocument): Promise<void> {
-  const targetURI = isTest(document) ? sourceURI(document) : testURI(document);
+  const targetURI = isTest(document) ? sourceURI(document) : testURI(document)
 
-  return workspace.openResource(targetURI);
+  return workspace.openResource(targetURI)
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 async function openTests(document: TextDocument): Promise<void> {
-  return workspace.openResource(testURI(document));
+  return workspace.openResource(testURI(document))
 }
 
 export function isTest(document: TextDocument): boolean {
-  return document.uri.endsWith('_test.go');
+  return document.uri.endsWith('_test.go')
 }
 
 function testURI(document: TextDocument): string {
-  return document.uri.replace(/(_test)?\.go$/, '_test.go');
+  return document.uri.replace(/(_test)?\.go$/, '_test.go')
 }
 
 function sourceURI(document: TextDocument): string {
-  return document.uri.replace(/(_test)?\.go$/, '.go');
+  return document.uri.replace(/(_test)?\.go$/, '.go')
 }
 
 async function runGotests(
@@ -81,29 +81,29 @@ async function runGotests(
 ): Promise<boolean> {
   const config = workspace
     .getConfiguration()
-    .get('go.tests', {}) as GoTestsConfig;
+    .get('go.tests', {}) as GoTestsConfig
 
   args.push(
     ...(config.generateFlags || []),
     '-w',
     URI.parse(document.uri).fsPath
-  );
+  )
   try {
-    const stdout = await execTool(GOTESTS, args);
-    workspace.showMessage(stdout || '');
+    const stdout = await execTool(GOTESTS, args)
+    workspace.showMessage(stdout || '')
 
-    return true;
+    return true
   } catch (err) {
-    workspace.showMessage(`Error: ${err}`, 'error');
-    return false;
+    workspace.showMessage(`Error: ${err}`, 'error')
+    return false
   }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 export function extractFunctionName(line: string): string | null {
-  const m = /^func +(\([^)]+\) +)?([^\s(]+)/.exec(line);
+  const m = /^func +(\([^)]+\) +)?([^\s(]+)/.exec(line)
   if (m) {
-    return m[2];
+    return m[2]
   }
 }

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,79 +1,90 @@
-import path from 'path'
-import fs from 'fs'
-import util from 'util'
-import { ExecOptions, exec, execFile, spawn } from 'child_process'
-import { workspace } from 'coc.nvim'
-import which from 'which'
-import { configDir } from './config'
+import path from 'path';
+import fs from 'fs';
+import util from 'util';
+import { ExecOptions, exec, execFile, spawn } from 'child_process';
+import { workspace } from 'coc.nvim';
+import which from 'which';
+import { configDir } from './config';
 
-const runExec = util.promisify(exec)
+const runExec = util.promisify(exec);
 
-const isWin = process.platform === 'win32'
+const isWin = process.platform === 'win32';
 
 ////////////////////////////////////////////////////////////////////////////////
 
-export async function installGoBin(source: string, force = false): Promise<boolean> {
-  const name = goBinName(source)
+export async function installGoBin(
+  source: string,
+  force = false
+): Promise<boolean> {
+  const name = goBinName(source);
 
-  if (!force && await goBinExists(name)) {
-    return true
+  if (!force && (await goBinExists(name))) {
+    return true;
   }
 
-  const statusItem = workspace.createStatusBarItem(90, { progress: true })
-  statusItem.text = `Installing '${name}'`
-  statusItem.show()
+  const statusItem = workspace.createStatusBarItem(90, { progress: true });
+  statusItem.text = `Installing '${name}'`;
+  statusItem.show();
 
-  const success = await goRun(`get ${source}@latest`) && await goBinExists(name)
+  const success =
+    (await goRun(`get ${source}@latest`)) && (await goBinExists(name));
 
   if (success) {
-    workspace.showMessage(`Installed '${name}'`)
+    workspace.showMessage(`Installed '${name}'`);
   } else {
-    workspace.showMessage(`Failed to install '${name}'`, 'error')
+    workspace.showMessage(`Failed to install '${name}'`, 'error');
   }
 
-  statusItem.hide()
-  return success
+  statusItem.hide();
+  return success;
 }
 
 export async function goBinPath(source: string): Promise<string> {
-  const name = goBinName(source)
-  return path.join(await configDir('bin'), name + (isWin ? ".exe" : ""))
+  const name = goBinName(source);
+  return path.join(await configDir('bin'), name + (isWin ? '.exe' : ''));
 }
 
-export async function runGoTool(name: string, args: string[] = []): Promise<[number, string]> {
-  const bin = await goBinPath(name)
+export async function runGoTool(
+  name: string,
+  args: string[] = []
+): Promise<[number, string]> {
+  const bin = await goBinPath(name);
   return new Promise((resolve): void => {
-    const p = spawn(bin, args)
+    const p = spawn(bin, args);
 
-    let out = ""
-    p.stdout.on('data', (data) => out += data)
+    let out = '';
+    p.stdout.on('data', (data) => (out += data));
 
-    p.on("close", code => resolve([code, out]))
-  })
+    p.on('close', (code) => resolve([code, out]));
+  });
 }
 
 export async function commandExists(command: string): Promise<boolean> {
   if (path.isAbsolute(command)) {
-    return fileExists(command)
+    return fileExists(command);
   }
-  return new Promise((resolve): void => { which(command, (err) => resolve(err == null)) })
+  return new Promise((resolve): void => {
+    which(command, (err) => resolve(err == null));
+  });
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 async function goBinExists(source: string): Promise<boolean> {
-  const name = goBinName(source)
-  const bin = await goBinPath(name)
-  return fileExists(bin)
+  const name = goBinName(source);
+  const bin = await goBinPath(name);
+  return fileExists(bin);
 }
 
 async function fileExists(path: string): Promise<boolean> {
-  return new Promise((resolve): void => fs.open(path, 'r', (err) => resolve(err === null)))
+  return new Promise((resolve): void =>
+    fs.open(path, 'r', (err) => resolve(err === null))
+  );
 }
 
 async function goRun(args: string): Promise<boolean> {
-  const gopath = await configDir('tools')
-  const gobin = await configDir('bin')
+  const gopath = await configDir('tools');
+  const gobin = await configDir('bin');
 
   const env = {
     GO111MODULE: 'on',
@@ -81,67 +92,71 @@ async function goRun(args: string): Promise<boolean> {
     GOPATH: gopath,
     GOROOT: '',
     GOTOOLDIR: '',
-  }
-  const cmd = isWin
-    ? `go ${args}`
-    : `env GOBIN=${gobin} go ${args}`
+  };
+  const cmd = isWin ? `go ${args}` : `env GOBIN=${gobin} go ${args}`;
   const opts: ExecOptions = {
     env: Object.assign({}, process.env, env),
     cwd: gopath,
     shell: isWin ? undefined : process.env.SHELL,
     windowsHide: true,
-  }
+  };
 
   try {
-    await runExec(cmd, opts)
+    await runExec(cmd, opts);
   } catch (ex) {
-    workspace.showMessage(ex, 'error')
-    return false
+    workspace.showMessage(ex, 'error');
+    return false;
   }
 
-  return true
+  return true;
 }
 
 interface execError {
-  code?: string
+  code?: string;
 }
 
-export async function execTool(source: string, args: string[], input?: string): Promise<string> {
+export async function execTool(
+  source: string,
+  args: string[],
+  input?: string
+): Promise<string> {
+  const [bin, name] = await Promise.all([goBinPath(source), goBinName(source)]);
 
-  const [bin, name] = await Promise.all([
-    goBinPath(source),
-    goBinName(source),
-  ])
-
-  if (!await commandExists(bin)) {
-    await installGoBin(source)
+  if (!(await commandExists(bin))) {
+    await installGoBin(source);
   }
 
   return new Promise((resolve, reject) => {
-    const p = execFile(bin, args, { cwd: workspace.cwd }, async (err: Error, stdout: Buffer, stderr: Buffer) => {
-      if (err && (err as execError).code === "ENOENT") {
-        return reject(`Error: Command ${name} not found! Run "CocCommand go.install.${name}" to install it and try again.`)
-      }
+    const p = execFile(
+      bin,
+      args,
+      { cwd: workspace.cwd },
+      async (err: Error, stdout: Buffer, stderr: Buffer) => {
+        if (err && (err as execError).code === 'ENOENT') {
+          return reject(
+            `Error: Command ${name} not found! Run "CocCommand go.install.${name}" to install it and try again.`
+          );
+        }
 
-      if (err) {
-        return reject(stderr.toString())
-      }
+        if (err) {
+          return reject(stderr.toString());
+        }
 
-      return resolve(stdout.toString())
-    })
+        return resolve(stdout.toString());
+      }
+    );
 
     if (p.pid) {
-      p.stdin.end(input)
+      p.stdin.end(input);
     }
-  })
-
+  });
 }
-
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
 function goBinName(source: string): string {
-  return source.replace(/\/\.\.\.$/, '').split('/').pop()
+  return source
+    .replace(/\/\.\.\.$/, '')
+    .split('/')
+    .pop();
 }
-

--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -1,14 +1,14 @@
-import path from 'path';
-import fs from 'fs';
-import util from 'util';
-import { ExecOptions, exec, execFile, spawn } from 'child_process';
-import { workspace } from 'coc.nvim';
-import which from 'which';
-import { configDir } from './config';
+import path from 'path'
+import fs from 'fs'
+import util from 'util'
+import { ExecOptions, exec, execFile, spawn } from 'child_process'
+import { workspace } from 'coc.nvim'
+import which from 'which'
+import { configDir } from './config'
 
-const runExec = util.promisify(exec);
+const runExec = util.promisify(exec)
 
-const isWin = process.platform === 'win32';
+const isWin = process.platform === 'win32'
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -16,75 +16,75 @@ export async function installGoBin(
   source: string,
   force = false
 ): Promise<boolean> {
-  const name = goBinName(source);
+  const name = goBinName(source)
 
   if (!force && (await goBinExists(name))) {
-    return true;
+    return true
   }
 
-  const statusItem = workspace.createStatusBarItem(90, { progress: true });
-  statusItem.text = `Installing '${name}'`;
-  statusItem.show();
+  const statusItem = workspace.createStatusBarItem(90, { progress: true })
+  statusItem.text = `Installing '${name}'`
+  statusItem.show()
 
   const success =
-    (await goRun(`get ${source}@latest`)) && (await goBinExists(name));
+    (await goRun(`get ${source}@latest`)) && (await goBinExists(name))
 
   if (success) {
-    workspace.showMessage(`Installed '${name}'`);
+    workspace.showMessage(`Installed '${name}'`)
   } else {
-    workspace.showMessage(`Failed to install '${name}'`, 'error');
+    workspace.showMessage(`Failed to install '${name}'`, 'error')
   }
 
-  statusItem.hide();
-  return success;
+  statusItem.hide()
+  return success
 }
 
 export async function goBinPath(source: string): Promise<string> {
-  const name = goBinName(source);
-  return path.join(await configDir('bin'), name + (isWin ? '.exe' : ''));
+  const name = goBinName(source)
+  return path.join(await configDir('bin'), name + (isWin ? '.exe' : ''))
 }
 
 export async function runGoTool(
   name: string,
   args: string[] = []
 ): Promise<[number, string]> {
-  const bin = await goBinPath(name);
+  const bin = await goBinPath(name)
   return new Promise((resolve): void => {
-    const p = spawn(bin, args);
+    const p = spawn(bin, args)
 
-    let out = '';
-    p.stdout.on('data', (data) => (out += data));
+    let out = ''
+    p.stdout.on('data', (data) => (out += data))
 
-    p.on('close', (code) => resolve([code, out]));
-  });
+    p.on('close', (code) => resolve([code, out]))
+  })
 }
 
 export async function commandExists(command: string): Promise<boolean> {
   if (path.isAbsolute(command)) {
-    return fileExists(command);
+    return fileExists(command)
   }
   return new Promise((resolve): void => {
-    which(command, (err) => resolve(err == null));
-  });
+    which(command, (err) => resolve(err == null))
+  })
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 async function goBinExists(source: string): Promise<boolean> {
-  const name = goBinName(source);
-  const bin = await goBinPath(name);
-  return fileExists(bin);
+  const name = goBinName(source)
+  const bin = await goBinPath(name)
+  return fileExists(bin)
 }
 
 async function fileExists(path: string): Promise<boolean> {
   return new Promise((resolve): void =>
     fs.open(path, 'r', (err) => resolve(err === null))
-  );
+  )
 }
 
 async function goRun(args: string): Promise<boolean> {
-  const gopath = await configDir('tools');
-  const gobin = await configDir('bin');
+  const gopath = await configDir('tools')
+  const gobin = await configDir('bin')
 
   const env = {
     GO111MODULE: 'on',
@@ -92,27 +92,27 @@ async function goRun(args: string): Promise<boolean> {
     GOPATH: gopath,
     GOROOT: '',
     GOTOOLDIR: '',
-  };
-  const cmd = isWin ? `go ${args}` : `env GOBIN=${gobin} go ${args}`;
+  }
+  const cmd = isWin ? `go ${args}` : `env GOBIN=${gobin} go ${args}`
   const opts: ExecOptions = {
     env: Object.assign({}, process.env, env),
     cwd: gopath,
     shell: isWin ? undefined : process.env.SHELL,
     windowsHide: true,
-  };
-
-  try {
-    await runExec(cmd, opts);
-  } catch (ex) {
-    workspace.showMessage(ex, 'error');
-    return false;
   }
 
-  return true;
+  try {
+    await runExec(cmd, opts)
+  } catch (ex) {
+    workspace.showMessage(ex, 'error')
+    return false
+  }
+
+  return true
 }
 
 interface execError {
-  code?: string;
+  code?: string
 }
 
 export async function execTool(
@@ -120,10 +120,10 @@ export async function execTool(
   args: string[],
   input?: string
 ): Promise<string> {
-  const [bin, name] = await Promise.all([goBinPath(source), goBinName(source)]);
+  const [bin, name] = await Promise.all([goBinPath(source), goBinName(source)])
 
   if (!(await commandExists(bin))) {
-    await installGoBin(source);
+    await installGoBin(source)
   }
 
   return new Promise((resolve, reject) => {
@@ -135,21 +135,21 @@ export async function execTool(
         if (err && (err as execError).code === 'ENOENT') {
           return reject(
             `Error: Command ${name} not found! Run "CocCommand go.install.${name}" to install it and try again.`
-          );
+          )
         }
 
         if (err) {
-          return reject(stderr.toString());
+          return reject(stderr.toString())
         }
 
-        return resolve(stdout.toString());
+        return resolve(stdout.toString())
       }
-    );
+    )
 
     if (p.pid) {
-      p.stdin.end(input);
+      p.stdin.end(input)
     }
-  });
+  })
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -158,5 +158,5 @@ function goBinName(source: string): string {
   return source
     .replace(/\/\.\.\.$/, '')
     .split('/')
-    .pop();
+    .pop()
 }

--- a/src/utils/versions.test.ts
+++ b/src/utils/versions.test.ts
@@ -1,65 +1,68 @@
-import assert from 'assert'
-import { compareVersions, isValidVersion, parseVersion, version } from './versions'
+import assert from 'assert';
+import {
+  compareVersions,
+  isValidVersion,
+  parseVersion,
+  version,
+} from './versions';
 
-const v0: version = [0, 0, 0]
-const v1: version = [1, 0, 0]
-const v1_2: version = [1, 2, 0]
-const v1_2_3: version = [1, 2, 3]
+const v0: version = [0, 0, 0];
+const v1: version = [1, 0, 0];
+const v1_2: version = [1, 2, 0];
+const v1_2_3: version = [1, 2, 3];
 
 describe('isValidVersion()', () => {
   it('should recognise valid versions', () => {
-    assert.ok(isValidVersion('v1.0.0'))
-    assert.ok(isValidVersion('1.0.0'))
-    assert.ok(isValidVersion('0.1.0'))
-    assert.ok(isValidVersion('0.0.1'))
-    assert.ok(isValidVersion('0.0.0'))
-    assert.ok(isValidVersion('v0.0.0'))
-  })
+    assert.ok(isValidVersion('v1.0.0'));
+    assert.ok(isValidVersion('1.0.0'));
+    assert.ok(isValidVersion('0.1.0'));
+    assert.ok(isValidVersion('0.0.1'));
+    assert.ok(isValidVersion('0.0.0'));
+    assert.ok(isValidVersion('v0.0.0'));
+  });
 
   it('should recognise invalid versions', () => {
-    assert.ok(!isValidVersion('v 1.0.0'))
-    assert.ok(!isValidVersion('1'))
-    assert.ok(!isValidVersion('1.1'))
-  })
+    assert.ok(!isValidVersion('v 1.0.0'));
+    assert.ok(!isValidVersion('1'));
+    assert.ok(!isValidVersion('1.1'));
+  });
+});
 
-})
-
-describe("parseVersion()", () => {
-  it("should parse simple versions", () => {
-    assert.deepStrictEqual(parseVersion('v0.0.0'), v0)
-    assert.deepStrictEqual(parseVersion('v1.0.0'), v1)
-    assert.deepStrictEqual(parseVersion('v1.2.0'), v1_2)
-    assert.deepStrictEqual(parseVersion('v1.2.3'), v1_2_3)
-  })
-})
+describe('parseVersion()', () => {
+  it('should parse simple versions', () => {
+    assert.deepStrictEqual(parseVersion('v0.0.0'), v0);
+    assert.deepStrictEqual(parseVersion('v1.0.0'), v1);
+    assert.deepStrictEqual(parseVersion('v1.2.0'), v1_2);
+    assert.deepStrictEqual(parseVersion('v1.2.3'), v1_2_3);
+  });
+});
 
 describe('compareVersions()', () => {
   it('should compare equal version', () => {
-    assert.throws(() => compareVersions('', ''))
-    assert.strictEqual(compareVersions('1.0.0', '1.0.0'), 0)
-    assert.strictEqual(compareVersions('1.2.0', '1.2.0'), 0)
-    assert.strictEqual(compareVersions('1.2.3', '1.2.3'), 0)
-    assert.strictEqual(compareVersions('v1.0.0', '1.0.0'), 0)
-  })
+    assert.throws(() => compareVersions('', ''));
+    assert.strictEqual(compareVersions('1.0.0', '1.0.0'), 0);
+    assert.strictEqual(compareVersions('1.2.0', '1.2.0'), 0);
+    assert.strictEqual(compareVersions('1.2.3', '1.2.3'), 0);
+    assert.strictEqual(compareVersions('v1.0.0', '1.0.0'), 0);
+  });
 
   it('should compare greater version', () => {
-    assert.throws(() => compareVersions('', ''))
-    assert.strictEqual(compareVersions('2.0.0', '1.0.0'), 1)
-    assert.strictEqual(compareVersions('1.1.0', '1.0.0'), 1)
-    assert.strictEqual(compareVersions('1.0.4', '1.0.0'), 1)
+    assert.throws(() => compareVersions('', ''));
+    assert.strictEqual(compareVersions('2.0.0', '1.0.0'), 1);
+    assert.strictEqual(compareVersions('1.1.0', '1.0.0'), 1);
+    assert.strictEqual(compareVersions('1.0.4', '1.0.0'), 1);
 
-    assert.strictEqual(compareVersions('v1.1.0', '1.0.0'), 1)
-    assert.strictEqual(compareVersions('1.1.0', 'v1.0.0'), 1)
-  })
+    assert.strictEqual(compareVersions('v1.1.0', '1.0.0'), 1);
+    assert.strictEqual(compareVersions('1.1.0', 'v1.0.0'), 1);
+  });
 
   it('should compare smaller version', () => {
-    assert.throws(() => compareVersions('', ''))
-    assert.strictEqual(compareVersions('1.0.0', '2.0.0'), -1)
-    assert.strictEqual(compareVersions('1.0.0', '1.1.0'), -1)
-    assert.strictEqual(compareVersions('1.0.0', '1.0.4'), -1)
+    assert.throws(() => compareVersions('', ''));
+    assert.strictEqual(compareVersions('1.0.0', '2.0.0'), -1);
+    assert.strictEqual(compareVersions('1.0.0', '1.1.0'), -1);
+    assert.strictEqual(compareVersions('1.0.0', '1.0.4'), -1);
 
-    assert.strictEqual(compareVersions('1.0.0', 'v1.1.0'), -1)
-    assert.strictEqual(compareVersions('v1.0.0', '1.1.0'), -1)
-  })
-
-})
+    assert.strictEqual(compareVersions('1.0.0', 'v1.1.0'), -1);
+    assert.strictEqual(compareVersions('v1.0.0', '1.1.0'), -1);
+  });
+});

--- a/src/utils/versions.test.ts
+++ b/src/utils/versions.test.ts
@@ -1,68 +1,68 @@
-import assert from 'assert';
+import assert from 'assert'
 import {
   compareVersions,
   isValidVersion,
   parseVersion,
   version,
-} from './versions';
+} from './versions'
 
-const v0: version = [0, 0, 0];
-const v1: version = [1, 0, 0];
-const v1_2: version = [1, 2, 0];
-const v1_2_3: version = [1, 2, 3];
+const v0: version = [0, 0, 0]
+const v1: version = [1, 0, 0]
+const v1_2: version = [1, 2, 0]
+const v1_2_3: version = [1, 2, 3]
 
 describe('isValidVersion()', () => {
   it('should recognise valid versions', () => {
-    assert.ok(isValidVersion('v1.0.0'));
-    assert.ok(isValidVersion('1.0.0'));
-    assert.ok(isValidVersion('0.1.0'));
-    assert.ok(isValidVersion('0.0.1'));
-    assert.ok(isValidVersion('0.0.0'));
-    assert.ok(isValidVersion('v0.0.0'));
-  });
+    assert.ok(isValidVersion('v1.0.0'))
+    assert.ok(isValidVersion('1.0.0'))
+    assert.ok(isValidVersion('0.1.0'))
+    assert.ok(isValidVersion('0.0.1'))
+    assert.ok(isValidVersion('0.0.0'))
+    assert.ok(isValidVersion('v0.0.0'))
+  })
 
   it('should recognise invalid versions', () => {
-    assert.ok(!isValidVersion('v 1.0.0'));
-    assert.ok(!isValidVersion('1'));
-    assert.ok(!isValidVersion('1.1'));
-  });
-});
+    assert.ok(!isValidVersion('v 1.0.0'))
+    assert.ok(!isValidVersion('1'))
+    assert.ok(!isValidVersion('1.1'))
+  })
+})
 
 describe('parseVersion()', () => {
   it('should parse simple versions', () => {
-    assert.deepStrictEqual(parseVersion('v0.0.0'), v0);
-    assert.deepStrictEqual(parseVersion('v1.0.0'), v1);
-    assert.deepStrictEqual(parseVersion('v1.2.0'), v1_2);
-    assert.deepStrictEqual(parseVersion('v1.2.3'), v1_2_3);
-  });
-});
+    assert.deepStrictEqual(parseVersion('v0.0.0'), v0)
+    assert.deepStrictEqual(parseVersion('v1.0.0'), v1)
+    assert.deepStrictEqual(parseVersion('v1.2.0'), v1_2)
+    assert.deepStrictEqual(parseVersion('v1.2.3'), v1_2_3)
+  })
+})
 
 describe('compareVersions()', () => {
   it('should compare equal version', () => {
-    assert.throws(() => compareVersions('', ''));
-    assert.strictEqual(compareVersions('1.0.0', '1.0.0'), 0);
-    assert.strictEqual(compareVersions('1.2.0', '1.2.0'), 0);
-    assert.strictEqual(compareVersions('1.2.3', '1.2.3'), 0);
-    assert.strictEqual(compareVersions('v1.0.0', '1.0.0'), 0);
-  });
+    assert.throws(() => compareVersions('', ''))
+    assert.strictEqual(compareVersions('1.0.0', '1.0.0'), 0)
+    assert.strictEqual(compareVersions('1.2.0', '1.2.0'), 0)
+    assert.strictEqual(compareVersions('1.2.3', '1.2.3'), 0)
+    assert.strictEqual(compareVersions('v1.0.0', '1.0.0'), 0)
+  })
 
   it('should compare greater version', () => {
-    assert.throws(() => compareVersions('', ''));
-    assert.strictEqual(compareVersions('2.0.0', '1.0.0'), 1);
-    assert.strictEqual(compareVersions('1.1.0', '1.0.0'), 1);
-    assert.strictEqual(compareVersions('1.0.4', '1.0.0'), 1);
+    assert.throws(() => compareVersions('', ''))
+    assert.strictEqual(compareVersions('2.0.0', '1.0.0'), 1)
+    assert.strictEqual(compareVersions('1.1.0', '1.0.0'), 1)
+    assert.strictEqual(compareVersions('1.0.4', '1.0.0'), 1)
 
-    assert.strictEqual(compareVersions('v1.1.0', '1.0.0'), 1);
-    assert.strictEqual(compareVersions('1.1.0', 'v1.0.0'), 1);
-  });
+    assert.strictEqual(compareVersions('v1.1.0', '1.0.0'), 1)
+    assert.strictEqual(compareVersions('1.1.0', 'v1.0.0'), 1)
+  })
 
   it('should compare smaller version', () => {
-    assert.throws(() => compareVersions('', ''));
-    assert.strictEqual(compareVersions('1.0.0', '2.0.0'), -1);
-    assert.strictEqual(compareVersions('1.0.0', '1.1.0'), -1);
-    assert.strictEqual(compareVersions('1.0.0', '1.0.4'), -1);
+    assert.throws(() => compareVersions('', ''))
+    assert.strictEqual(compareVersions('1.0.0', '2.0.0'), -1)
+    assert.strictEqual(compareVersions('1.0.0', '1.1.0'), -1)
+    assert.strictEqual(compareVersions('1.0.0', '1.0.4'), -1)
 
-    assert.strictEqual(compareVersions('1.0.0', 'v1.1.0'), -1);
-    assert.strictEqual(compareVersions('v1.0.0', '1.1.0'), -1);
-  });
-});
+    assert.strictEqual(compareVersions('1.0.0', 'v1.1.0'), -1)
+    assert.strictEqual(compareVersions('v1.0.0', '1.1.0'), -1)
+  })
+})

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,36 +1,36 @@
-export type version = [number, number, number];
+export type version = [number, number, number]
 
-const versionExp = /^v?(\d+)\.(\d+).(\d+)$/;
+const versionExp = /^v?(\d+)\.(\d+).(\d+)$/
 
 export function isValidVersion(version: string): boolean {
-  return Boolean(version.trim().match(versionExp));
+  return Boolean(version.trim().match(versionExp))
 }
 
 export function compareVersions(version1: string, version2: string): number {
-  const v1 = parseVersion(version1);
-  const v2 = parseVersion(version2);
+  const v1 = parseVersion(version1)
+  const v2 = parseVersion(version2)
 
   for (let i = 0; i < 3; i++) {
     if (v1[i] !== v2[i]) {
-      return Math.max(-1, Math.min(1, v1[i] - v2[i]));
+      return Math.max(-1, Math.min(1, v1[i] - v2[i]))
     }
   }
 
-  return 0;
+  return 0
 }
 
 export function parseVersion(v: string): version {
-  let ver: version = [0, 0, 0];
-  const match = v.trim().match(versionExp);
+  let ver: version = [0, 0, 0]
+  const match = v.trim().match(versionExp)
 
   if (match) {
-    const [, major, minor, patch] = match;
-    ver = [parseInt(major), parseInt(minor), parseInt(patch)];
+    const [, major, minor, patch] = match
+    ver = [parseInt(major), parseInt(minor), parseInt(patch)]
   }
 
   if (!isValidVersion(v)) {
-    throw new Error(`'${v}' is not a valid version`);
+    throw new Error(`'${v}' is not a valid version`)
   }
 
-  return ver;
+  return ver
 }

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -1,43 +1,36 @@
-export type version = [
-  number,
-  number,
-  number,
-]
+export type version = [number, number, number];
 
-const versionExp = /^v?(\d+)\.(\d+).(\d+)$/
+const versionExp = /^v?(\d+)\.(\d+).(\d+)$/;
 
 export function isValidVersion(version: string): boolean {
-  return Boolean(version.trim().match(versionExp))
+  return Boolean(version.trim().match(versionExp));
 }
 
 export function compareVersions(version1: string, version2: string): number {
-  const v1 = parseVersion(version1)
-  const v2 = parseVersion(version2)
+  const v1 = parseVersion(version1);
+  const v2 = parseVersion(version2);
 
   for (let i = 0; i < 3; i++) {
-
     if (v1[i] !== v2[i]) {
-      return Math.max(-1, Math.min(1, v1[i] - v2[i]))
+      return Math.max(-1, Math.min(1, v1[i] - v2[i]));
     }
   }
 
-  return 0
+  return 0;
 }
 
 export function parseVersion(v: string): version {
-
-  let ver: version = [0, 0, 0]
-  const match = v.trim().match(versionExp)
+  let ver: version = [0, 0, 0];
+  const match = v.trim().match(versionExp);
 
   if (match) {
-    const [, major, minor, patch] = match
-    ver = [parseInt(major), parseInt(minor), parseInt(patch)]
+    const [, major, minor, patch] = match;
+    ver = [parseInt(major), parseInt(minor), parseInt(patch)];
   }
 
   if (!isValidVersion(v)) {
-    throw new Error(`'${v}' is not a valid version`)
+    throw new Error(`'${v}' is not a valid version`);
   }
 
-  return ver
+  return ver;
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -1700,6 +1700,11 @@ prettier@^2.1.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
+prettier@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
Signed-off-by: Cheng JIANG <alex_cj96@foxmail.com>

this adds `go.debug.test.nearest` command. The vimspector should look like this:

```json
{
      "configuration": {
        "launch": {
            "adapter": "vscode-go",
            "configuration": {
                "request": "launch",
                "program": "${workspaceFolder}",
                "mode": "test",
                "dlvToolPath": "/$HOME/.goenv/shims/dlv",
                "trace": true,
                "env": { "GO111MODULE": "on" },
                "args": ["-test.run", "${TestIdentifier}"]
            }
        }
  }
}
```

![image](https://user-images.githubusercontent.com/33961674/103155498-d9d6bb00-47a0-11eb-9cf7-db8b5dfec667.png)

Ref: #125 
