### PR TITLE
fix gobin contain space

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -90,7 +90,7 @@ async function goRun(args: string): Promise<boolean> {
   }
   const cmd = isWin
     ? `go ${args}`
-    : `env GOBIN=${gobin} go ${args}`
+    : `env GOBIN="${gobin}" go ${args}`
   const opts: ExecOptions = {
     env: Object.assign({}, process.env, env),
     cwd: gopath,


### PR DESCRIPTION
i put ~/.config to icloud to sync cross machine

so

`env GOBIN=/Users/user/Library/Mobile Documents/com~apple~CloudDocs/Cloud/home/_config/coc/extensions/coc-go-data/bin`

contains a space

and let command failed

`env: Documents/com~apple~CloudDocs/Cloud/home/_config/coc/extensions/coc-go-data/bin: No such file or directory`
