### PR TITLE
Add var block snippet

### DIFF
--- a/snippets/go.json
+++ b/snippets/go.json
@@ -76,6 +76,15 @@
     ],
     "description": "a variable"
   },
+  "multiple variables": {
+    "prefix": "vars",
+    "body": [
+      "var (",
+      "\t${1:name} = ${2:value}",
+      ")"
+    ],
+    "description": "a variable block"
+  },
   "switch statement": {
     "prefix": "switch",
     "body": [


### PR DESCRIPTION
We have block snippet for const, imports but a block snippet for var is
missing.
This pr intends to add var block snippet.