### PR TITLE
feat: Inlay hints support

### DIFF
--- a/package.json
+++ b/package.json
@@ -790,7 +790,7 @@
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "coc-dev-tools": "^0.1.0",
-    "coc.nvim": "^0.0.80",
+    "coc.nvim": "^0.0.81",
     "eslint": "^8.12.0",
     "eslint-config-josa-typescript": "^0.1.2",
     "jest": "^27.5.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { generateTestsAll, generateTestsExported, generateTestsFunction, toogleT
 import { openPlayground } from './utils/playground'
 import { generateImplStubs } from './utils/impl'
 import { goplsTidy } from './utils/lspcommands'
+import * as goplsInlayHintsFeature from './inlayHints'
 
 const restartConfigs = [
   'go.goplsArgs',
@@ -105,6 +106,8 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
       () => installGopls(client)
     )
   )
+
+  goplsInlayHintsFeature.register(context, client)
 }
 
 async function goplsPath(goplsPath: string): Promise<string | null> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import os from 'os'
 import { commandExists, goBinPath, installGoBin } from './utils/tools'
 import { checkGopls, installGomodifytags, installGoplay, installGopls, installGotests, installImpl, installTools, version } from './commands'
 import { addTags, clearTags, removeTags } from './utils/modify-tags'
-import { getConfig, setStoragePath } from './utils/config'
+import { getConfig, getLanguageClientDisabledFeatures, setStoragePath } from './utils/config'
 import { activeTextDocument } from './editor'
 import { GOPLS } from './binaries'
 import { generateTestsAll, generateTestsExported, generateTestsFunction, toogleTests } from './utils/tests'
@@ -80,10 +80,7 @@ async function registerGopls(context: ExtensionContext): Promise<void> {
   const clientOptions: LanguageClientOptions = {
     documentSelector: ['go', 'gomod', 'gowork'],
     initializationOptions: () => getConfig().goplsOptions,
-    disableWorkspaceFolders: config.disable.workspaceFolders,
-    disableDiagnostics: config.disable.diagnostics,
-    disableCompletion: config.disable.completion,
-    // TODO disableSnippetCompletion: config.disable.snippetCompletion,
+    disabledFeatures: getLanguageClientDisabledFeatures(),
   }
 
   const client = new LanguageClient('go', 'gopls', server, clientOptions)

--- a/src/inlayHints.ts
+++ b/src/inlayHints.ts
@@ -1,0 +1,48 @@
+import { DocumentSelector, ExtensionContext, InlayHint, InlayHintsProvider, LanguageClient, Range, TextDocument, languages } from 'coc.nvim'
+
+export async function register(context: ExtensionContext, client: LanguageClient) {
+  await client.onReady()
+
+  const documentSelector: DocumentSelector = [{ language: 'go', scheme: 'file' }]
+  context.subscriptions.push(
+    languages.registerInlayHintsProvider(documentSelector, new GoplsInlayHintsProvider(client))
+  )
+}
+
+export class GoplsInlayHintsProvider implements InlayHintsProvider {
+  client: LanguageClient
+  constructor(client: LanguageClient) {
+    this.client = client
+  }
+
+  async provideInlayHints(
+    document: TextDocument,
+    range: Range,
+  ) {
+    const inlayHints: InlayHint[] = []
+
+    const response: InlayHint[] = await this.client.sendRequest('textDocument/inlayHint', {
+      textDocument: { uri: document.uri },
+      range
+    })
+
+    if (response) {
+      response.forEach((r) => {
+        const hint: InlayHint = {
+          label: r.label,
+          position: r.position,
+          kind: r.kind ?? r.kind,
+          paddingLeft: r.paddingLeft ? r.paddingLeft : undefined,
+          paddingRight: r.paddingRight ? r.paddingRight : undefined,
+          textEdits: r.textEdits ? r.textEdits : undefined,
+          tooltip: r.tooltip ? r.tooltip : undefined,
+          data: r.data ? r.data : undefined,
+        }
+
+        inlayHints.push(hint)
+      })
+    }
+
+    return inlayHints
+  }
+}

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -25,6 +25,7 @@ export interface GoConfig {
   tests: GoTestsConfig
   checkForUpdates: "disabled" | "inform" | "ask" | "install"
   disable: DisableConfig
+  disabledFeatures?: string[]
 }
 
 export interface DisableConfig {
@@ -259,3 +260,10 @@ export async function setState<T>(key: string, value: T) {
   await setStateData(d)
 }
 
+export function getLanguageClientDisabledFeatures() {
+  const r: string[] = []
+  if (getConfig().disable.completion) r.push('completion')
+  if (getConfig().disable.workspaceFolders) r.push('workspaceFolders')
+  if (getConfig().disable.diagnostics) r.push('diagnostics')
+  return r
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,10 +1108,10 @@ coc-dev-tools@^0.1.0:
     prettier "^2.1.2"
     yargs "^16.0.3"
 
-coc.nvim@^0.0.80:
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.80.tgz#785145c382660db03f517f9b497900d95cbd0e4f"
-  integrity sha512-/3vTcnofoAYMrdENrlQmADTzfXX4+PZ0fiM10a39UA37dTR2dpIGi9O469kcIksuunLjToqWG8S45AGx/9wV7g==
+coc.nvim@^0.0.81:
+  version "0.0.81"
+  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.81.tgz#6c28ed4e773e7f274f1c295dd4fa2d46e351d306"
+  integrity sha512-e9FSAXPNs3vAgjSrspYRuPcX8L+AQw1T+0SfY0srJ6tsDtWnainnwSvyjInw1tEmGXRMgdBmVowW0JY2qjv9Dw==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## Description

Recent `gopls` updates support inlay hints. I added support for inlay hints in `coc-go`.

"v0.0.81" is required to smoothly add inlay hints feature in `coc.nvim`. Upgraded `coc.nvim` to "v0.0.81" with existing `coc-go` and made necessary adjustments. (e.g. `disabledFeatures`)

## DEMO (mp4)

**coc-settings.json**:

```jsonc
  "go.goplsOptions": {
    // ...snip
    "hints": {
      "constantValues": true,
      "parameterNames": true,
      "rangeVariableTypes": true,
      "assignVariableTypes": true,
      "compositeLiteralTypes": true,
      "compositeLiteralFields": true,
      "functionTypeParameters": true
    },
    // ...snip
  },
```

https://user-images.githubusercontent.com/188642/179625098-b95adeee-6b1d-4182-a925-870930b1fa1c.mp4


