### PR TITLE
fix(workspace): go.work as root

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
       {
         "filetype": "go",
         "patterns": [
-          "go.mod"
+          "go.mod",
+          "go.work"
         ]
       },
       {


### PR DESCRIPTION
This PR makes use of go.work as the workspace root.

This fixes an issue if you have the following structure:

- go.mod
- packages
  - go.work
  - pkg1
    - go.mod
    - pkg1.go
   - pkg2
     - go.mod
     - pkg2.go

When you're located in `packages` and run `vim pkg1/pkg1.go`, the current behavior is to use the root go.mod as the workspace.
However, gopls fails to load a [go.work workspace in subdirectories](https://cs.opensource.google/go/x/tools/+/e0ecd1bca65b7cbf8303ba916eebdfc66ef8a68b:gopls/internal/lsp/cache/load.go;l=390).

In this scenario, it makes sense to use the go.work as the workspace root.