### PR TITLE
fix: properly detect non-absolute goplsPath

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -92,7 +92,8 @@ export async function commandExists(command: string): Promise<boolean> {
   if (path.isAbsolute(command)) {
     return fileExists(command)
   }
-  return new Promise((resolve): void => { which(command, (err) => resolve(err == null)) })
+  const commandPath = await which(command, { nothrow: true })
+  return commandPath !== null
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
node-which v3 apparently had an API change that resulted in coc-go not being able to find gopls in `PATH`.
