### PR TITLE
fix: parse Go version with build metadata

### DIFF
--- a/src/utils/tools.ts
+++ b/src/utils/tools.ts
@@ -5,7 +5,7 @@ import { ExecOptions, exec, execFile, spawn } from 'child_process'
 import { window, workspace } from 'coc.nvim'
 import which from 'which'
 import { configDir } from './config'
-import { compareVersions } from './versions'
+import { compareVersions, parseGoVersion } from './versions'
 
 const runExec = util.promisify(exec)
 
@@ -61,7 +61,7 @@ async function goVersionOrLater(version: string): Promise<boolean> {
 async function getGoVersion() {
   try {
     const [, out] = await runBin('go', ['version'])
-    return out.trim().match(/^go version go(\S+) .*$/)[1]
+    return parseGoVersion(out)
   } catch(err) {
     // mute
   }

--- a/src/utils/versions.test.ts
+++ b/src/utils/versions.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { compareVersions, isValidVersion, parseVersion, version } from './versions'
+import { compareVersions, isValidVersion, parseGoVersion, parseVersion, version } from './versions'
 
 const v0_0_0: version = [0, 0, 0]
 const v1_0_0: version = [1, 0, 0]
@@ -63,4 +63,22 @@ describe('compareVersions()', () => {
     assert.strictEqual(compareVersions('v1.0.0', '1.1.0'), -1)
   })
 
+})
+
+describe('parseGoVersion()', () => {
+  it('parses official version', () => {
+    assert.strictEqual(parseGoVersion('go version go1.26.5 linux/amd64'), '1.26.5')
+  })
+
+  it('parses distro version with metadata suffix', () => {
+    assert.strictEqual(parseGoVersion('go version go1.26.5-X:nodwarf5 linux/amd64'), '1.26.5')
+  })
+
+  it('parses two-part version', () => {
+    assert.strictEqual(parseGoVersion('go version go1.26 linux/amd64'), '1.26')
+  })
+
+  it('returns empty for malformed output', () => {
+    assert.strictEqual(parseGoVersion(''), '')
+  })
 })

--- a/src/utils/versions.ts
+++ b/src/utils/versions.ts
@@ -41,3 +41,9 @@ export function parseVersion(v: string): version {
   return ver
 }
 
+const goVersionExp = /^go version go(\d+\.\d+(?:\.\d+)?)/
+
+export function parseGoVersion(output: string): string {
+  const m = output.trim().match(goVersionExp)
+  return m ? m[1] : ''
+}


### PR DESCRIPTION
Fixes #229

## Problem

coc-go fails to install gopls with:

```
env GOBIN=".../coc-go-data/bin" go get golang.org/x/tools/gopls@latest
go: go.mod file not found in current directory or any parent directory.
'go get' is no longer supported outside a module.
```

**Version parsing falls back to `go get`.** `goInstall()` uses `go install` only when `goVersionOrLater('1.17.0')` is true. `getGoVersion()` captured the entire version token from `go version`, including distro build metadata such as `1.26.5-X:nodwarf5`. The trailing `-X:nodwarf5` makes `compareVersions()` throw, `goVersionOrLater()` catches it and returns `false`, so `goInstall()` falls back to the deprecated `go get`, which fails outside a module.

## Changes

- Add `parseGoVersion()` in `versions.ts` to extract only the numeric version (`1.26.5`) from `go version` output, ignoring build metadata. `getGoVersion()` now uses it, so `goVersionOrLater('1.17.0')` returns true on distro Go builds and `goInstall()` uses `go install`.

## Testing

- Added unit tests for `parseGoVersion()` (official version, `-X:nodwarf5` suffix, two-part, malformed).
- `npm test` passes (23 tests).
